### PR TITLE
Fix table of contents

### DIFF
--- a/docs
+++ b/docs
@@ -50,9 +50,10 @@ case $action in
     esac || true
   }
 
+  asciid getting-started.adoc
+  
   asciid index.adoc
-  # getting started is just a different collection of topics, but it breaks the TOC in the main docs
-  #asciid getting-started.adoc
+  
   find "$gamedir" -name "*.adoc" | while read -r adoc; do
     # save the first word of the file to $word
     read -r word _<"$adoc";

--- a/docs
+++ b/docs
@@ -23,9 +23,10 @@ case $action in
   ;;
 
 (generate)
+  PS4='+${BASH_SOURCE}:${LINENO}${FUNCNAME[0]:+-${FUNCNAME[0]}()}> '
   for arg in "$@" ; do
-    [ "$arg" = "pdf" ] && pdf="true" && continue
-    [ "$arg" = "-v" ] && verbose="-v" && continue
+    test "$arg" = "pdf" && pdf="true" && continue
+    test "$arg" = "-v" && verbose="-v" && set -o xtrace && continue
     game="$arg"
   done
   echo "Processing Game $game (pdf: ${pdf:-no})..."
@@ -40,13 +41,12 @@ case $action in
 
   # HTML & PDF
   asciid() {
-    target="$outdir/$(dirname "$1")"
-    if [ $# -ge 2 ];then
-      target="$outdir/$2/$(dirname "$1")"
-    fi
-    case $1 in (*spiele/*) target="$outdir/spiele/$(echo "$1" | cut -d/ -f2)"; esac
-    echo "Converting $1 to html"
-    bundle exec asciidoctor $verbose -D "$target" -r asciidoctor-multipage -b multipage_html5 "$1"
+    case $1 in
+      (*spiele/*) target="$outdir/spiele/$(echo "$1" | cut -d/ -f2)";;
+      (*) target="$outdir/$(test -n "$2" && echo "$2/")$(dirname "$1")";;
+    esac
+    echo "Converting $1 to html into $target"
+    bundle exec asciidoctor $verbose $(test -n "$2" && echo "-o $target/index.html" || echo "-D $target") -r asciidoctor-multipage -b multipage_html5 "$1"
     test "$pdf" && case "$1" in
       (*"$game/index.adoc") ;;
       (*) echo "Converting $1 to pdf" && bundle exec asciidoctor-pdf $verbose -D "$target" "$1";;
@@ -54,7 +54,8 @@ case $action in
   }
 
   asciid index.adoc
-  asciid getting-started.adoc "started"
+  # Separate folder to not mess up main ToC
+  asciid getting-started.adoc "getting-started"
   
   find "$gamedir" -name "*.adoc" | while read -r adoc; do
     # save the first word of the file to $word

--- a/docs
+++ b/docs
@@ -41,6 +41,9 @@ case $action in
   # HTML & PDF
   asciid() {
     target="$outdir/$(dirname "$1")"
+    if [ $# -ge 2 ];then
+      target="$outdir/$2/$(dirname "$1")"
+    fi
     case $1 in (*spiele/*) target="$outdir/spiele/$(echo "$1" | cut -d/ -f2)"; esac
     echo "Converting $1 to html"
     bundle exec asciidoctor $verbose -D "$target" -r asciidoctor-multipage -b multipage_html5 "$1"
@@ -50,9 +53,8 @@ case $action in
     esac || true
   }
 
-  asciid getting-started.adoc
-  
   asciid index.adoc
+  asciid getting-started.adoc "started"
   
   find "$gamedir" -name "*.adoc" | while read -r adoc; do
     # save the first word of the file to $word

--- a/getting-started.adoc
+++ b/getting-started.adoc
@@ -1,6 +1,4 @@
 :imagesdir: images
-:toc: auto
-:toc-title: Inhalt
 :source-highlighter: pygments
 :icons: font
 

--- a/getting-started.adoc
+++ b/getting-started.adoc
@@ -1,4 +1,6 @@
 :imagesdir: images
+:toc: left
+:toc-title: Inhalt
 :source-highlighter: pygments
 :icons: font
 

--- a/index.adoc
+++ b/index.adoc
@@ -1,4 +1,6 @@
 :imagesdir: images
+:toc: left
+:toc-title: Inhalt
 :source-highlighter: pygments
 :icons: font
 


### PR DESCRIPTION
Getting started and the index have seperate build targets now, meaning they can have seperate nav menus in their containing sites.
Since this updates the doc file please check whether this breaks anything else