### PR TITLE
hyperbook: update terms to new convention

### DIFF
--- a/hyperbook/book/allgemein/index.md
+++ b/hyperbook/book/allgemein/index.md
@@ -18,7 +18,7 @@ gesamten Schuljahres läuft, und der den Schülerinnen und Schülern die
 Möglichkeit bietet, mit Spaß und Spannung sowie mit kompetenter
 Begleitung in die Welt der Informatik einzusteigen. Am Ende der
 Entwicklungsphase schickt jedes Team (Kurs oder AG) einen selbst
-programmierten Computerspieler für das Spiel in den Wettkampf. Dieser
+programmierten :t[Computerspieler]{#player} für das Spiel in den Wettkampf. Dieser
 Wettkampf besteht zunächst aus einer kompletten Meisterschaft (jeder
 gegen jeden) und anschließend aus einem Finale der 8 führenden Teams
 (Final Eight). Als Preise winken neben zahlreichen Sachpreisen auch
@@ -35,8 +35,8 @@ mindestens 3 SchülerInnen und einer betreuenden Lehrkraft bestehen.
 Jeder Kurs bzw. jede AG darf nur ein Team anmelden. Dabei kann es in der
 Anfangsphase durchaus Sinn machen, intern in einem Team mehrere Gruppen
 zu bilden, um z.B. unterschiedliche Strategien zu testen und
-Computerspieler zu entwickeln. Spätestens zu Beginn der Wettkampfphase
-muss sich das Team jedoch auf einen Computerspieler einigen, der dann in
+:t[Computerspieler]{#player} zu entwickeln. Spätestens zu Beginn der Wettkampfphase
+muss sich das Team jedoch auf einen :t[Computerspieler]{#player} einigen, der dann in
 den Wettkampf geschickt und dann eventuell noch gemeinsam
 weiterentwickelt wird. In begründeten Einzelfällen kann die
 Wettkampfleitung Ausnahmen von den zuvor genannten Regeln zulassen.
@@ -71,13 +71,13 @@ aktualisieren.
 ## Die Aufgabe
 
 Die Software-Challenge basiert jedes Jahr auf einem Brettspiel, für das
-ein Computerspieler geschrieben werden soll und das entweder selbst
+ein :t[Computerspieler]{#player} geschrieben werden soll und das entweder selbst
 entwickelt oder auf Basis eines existierenden Brettspiels modifiziert
 wird. Im letzteren Fall werden wir durch die Spiel-Verlage unterstützt,
 indem diese uns die Genehmigung erteilen und Grafiken zur Verfügung
 stellen. Bei der Entwicklung bzw. Modifizierung der Spiele versuchen wir
 zu erreichen, dass die Spiele interessant, abwechslungsreich und nicht
 zu kompliziert sind und dass die Glückskomponente nicht dominiert. Ein
-sehr guter Computerspieler soll sich also langfristig gegen schwächere
+sehr guter :t[Computerspieler]{#player} soll sich also langfristig gegen schwächere
 durchsetzen, wobei es durchaus vorkommen darf, dass er bei viel Pech
 auch mal verliert.

--- a/hyperbook/book/allgemein/spiel.md
+++ b/hyperbook/book/allgemein/spiel.md
@@ -7,7 +7,7 @@ index: 3
 
 Um ein Computerprogramm zu schreiben, was ein Spiel spielen kann, muss
 man vorher das Spiel selbst verstehen und spielen können.  
-Dabei könnt ihr euch bereits Ideen und Strategien entwickeln, die ihr in euren Computerspieler nachher umsetzen wollt.
+Dabei könnt ihr euch bereits Ideen und Strategien entwickeln, die ihr in euren :t[Computerspieler]{#player} nachher umsetzen wollt.
 Das Spiel der Software-Challenge Germany 2023 ist "[Hey, Danke für den Fisch](spiele/penguins/penguins_spielregeln)".
 
-Das Spiel selbst kann zu zweit oder allein gegen den [SimpleClient](glossary/client#der-simpleclient) mit dem [Spielleiter](glossary/server#der-spielleiter-server) gespielt werden. Es empfielt sich, dies einige Male zu tun, bevor man mit der Programmierung beginnt.
+Das Spiel selbst kann zu zweit oder allein gegen den [Zufallsspieler](glossary/client#der-simpleclient) mit dem [Spielleiter](glossary/server#der-spielleiter-server) gespielt werden. Es empfielt sich, dies einige Male zu tun, bevor man mit der Programmierung beginnt.

--- a/hyperbook/book/allgemein/wettkampf.md
+++ b/hyperbook/book/allgemein/wettkampf.md
@@ -21,7 +21,7 @@ Teamanzahl in einer der Gruppen setzt an jedem Spieltag eines der Teams
 aus.
 
 Vor Beginn des ersten Spieltages soll jedes Team einen funktionsfähigen
-Client über das Online-Abgabesystem eingeschickt haben. Zwischen den
+:t[Computerspieler]{#player} über das Online-Abgabesystem eingeschickt haben. Zwischen den
 Spieltagen besteht die Möglichkeit, Clients ebenfalls über dieses System
 zu aktualisieren. Über das Online-Abgabesystem werden auch die
 Ergebnisse, Ranglisten etc. veröffentlicht.
@@ -37,17 +37,17 @@ Anzahl der Siegpunkte aus den bisherigen Spielen verwendet. Wenn am Ende
 einer Meisterschaft zwei Teams denselben Platz belegen, entscheidet das
 Los.
 
-## Die Champions-League
+## Die Champions League
 
 In diese zweite Phase (Mitte April bis Mitte Mai) kommen die besten acht
-Teams einer jeden Gruppe aus der ersten Phase. Die Champions-League wird
+Teams einer jeden Gruppe aus der ersten Phase. Die Champions League wird
 nach dem gleichen Schema wie eine Meisterschaft ausgespielt.
 
 ## Das Final Eight
 
 An der dritten Phase, dem Final Eight, das im Juni in Kiel stattfindet,
 nehmen die ersten acht Mannschaften der Rangliste aus der
-Champions-League teil. Viertelfinale, Halbfinale, Kleines Finale (=
+Champions League teil. Viertelfinale, Halbfinale, Kleines Finale (=
 Spiel um den 3. Platz) und Finale werden im KO-System gespielt.
 
 Jede Begegnung besteht aus jeweils sechs Spielen, wobei das Recht des
@@ -69,7 +69,7 @@ ersten Zuges abwechselt.
 
 Die Zugzeit ist für jeden Zug auf zwei Sekunden begrenzt. Dabei gilt für
 die Rechenzeit die im Institut verwendete Hardware als Referenz. Jeder
-Client wird dabei auf einer eigenen virtuellen Maschine mit unten
+:t[Computerspieler]{#player} wird dabei auf einer eigenen virtuellen Maschine mit unten
 stehenden Spezifikationen ausgeführt.
 
 Sollte ein Spieler einen ungültigen Zug setzen oder die maximale Zugzeit
@@ -101,12 +101,12 @@ laufen die :t[Computerspieler]{#player} auf den Servern des Wettkampfsystems.
 
 ### Log-Ausgabe
 
-Die Computerspieler laufen im :t[Wettkampfsystem]{#contest} ohne eine grafische
+Die :t[Computerspieler]{#player} laufen im :t[Wettkampfsystem]{#contest} ohne eine grafische
 Oberfläche, sie können also keine Fenster oder ähnliches anzeigen. Der
 Versuch eines Computerspielers, so etwas trotzdem zu tun, wird
 wahrscheinlich zum Absturz des Computerspielers führen.
 
-Die Computerspieler können jedoch Text auf die beiden
+Die :t[Computerspieler]{#player} können jedoch Text auf die beiden
 Standard-Ausgabedatenströme "stdout" und "stderr" schreiben. Diese
 Ausgaben finden sich dann in den Log-Dateien wieder, die nach Beenden
 eines Spiels über das :t[Wettkampfsystem]{#contest} verfügbar sind.
@@ -119,18 +119,18 @@ geschrieben wurden, zugegriffen werden.
 
 ### Weitere Ausführungsumgebung
 
-Der Computerspieler wird in einem sogenannten "Docker Container"
+Der :t[Computerspieler]{#player} wird in einem sogenannten "Docker Container"
 ausgeführt, welcher die verfügbaren Bibliotheken und Programme bestimmt.
 Folgende Container-Images können genutzt werden:
 
 | Bezeichnung        | Image-Name                                                                                   | Beschreibung                                                                                                               |
 | ------------------ | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| Java 8             | [openjdk:8u151-jre](https://hub.docker.com/_/openjdk/)                                       | Open Source Java Platform, Standard Edition, Version 1.8.0. Für alle Computerspieler auf Basis des Java SimpleClients.     |
-| Ruby 2             | [ruby:2.4.2](https://hub.docker.com/_/ruby/) mit installiertem Software-Challenge-Client-Gem | Ruby Interpreter, Version 2.4.2. Für alle Computerspieler auf Basis des Ruby SimpleClients.                                |
-| Python 3           | [python:3.6.3](https://hub.docker.com/_/python/)                                             | Python Interpreter, Version 3.6.3. Für selbst entwickelte Computerspieler in Python.                                       |
-| Mono 5.4 (C# .NET) | [mono:5.4.1.6](https://hub.docker.com/_/mono/)                                               | Mono Laufzeitumgebung, Version 5.4.1.6. Für selbst entwickelte Computerspieler basierend auf dem Microsoft .NET Framework. |
+| Java 8             | [openjdk:8u151-jre](https://hub.docker.com/_/openjdk/)                                       | Open Source Java Platform, Standard Edition, Version 1.8.0. Für alle :t[Computerspieler]{#player} auf Basis des Java SimpleClients.     |
+| Ruby 2             | [ruby:2.4.2](https://hub.docker.com/_/ruby/) mit installiertem Software-Challenge-Computerspieler-Gem | Ruby Interpreter, Version 2.4.2. Für alle :t[Computerspieler]{#player} auf Basis des Ruby SimpleClients.                                |
+| Python 3           | [python:3.6.3](https://hub.docker.com/_/python/)                                             | Python Interpreter, Version 3.6.3. Für selbst entwickelte :t[Computerspieler]{#player} in Python.                                       |
+| Mono 5.4 (C# .NET) | [mono:5.4.1.6](https://hub.docker.com/_/mono/)                                               | Mono Laufzeitumgebung, Version 5.4.1.6. Für selbst entwickelte :t[Computerspieler]{#player} basierend auf dem Microsoft .NET Framework. |
 
-Wenn Ihr Computerspieler eine speziellere Umgebung benötigt (zum
+Wenn Ihr :t[Computerspieler]{#player} eine speziellere Umgebung benötigt (zum
 Beispiel ein hier nicht angebotener Interpreter), nehmen sie bitte mit
-uns Kontakt auf (<svk@informatik.uni-kiel.de>). Wir stellen gern weitere
+uns Kontakt auf (<tech@software-challenge.de>). Wir stellen gern weitere
 Images zur Verfügung.

--- a/hyperbook/book/entwicklung/abgabe.md
+++ b/hyperbook/book/entwicklung/abgabe.md
@@ -3,20 +3,20 @@ name: Computerspieler abgabefertig machen
 index: 9
 ---
 
-# Computerspieler abgabefertig machen
+# :t[Computerspieler]{#player} abgabefertig machen
 
-Damit das :t[Wettkampfsystem]{#contest} mit dem Computerspieler arbeiten kann,
+Damit das :t[Wettkampfsystem]{#contest} mit dem :t[Computerspieler]{#player} arbeiten kann,
 muss er als ausführbares Programm in ein ZIP-Archiv gepackt werden.
 
-Je nach Programmiersprache, in der der Computerspieler entwickelt wurde,
+Je nach Programmiersprache, in der der :t[Computerspieler]{#player} entwickelt wurde,
 sind unterschiedliche Schritte notwendig.
 
-Wie man den abgabefertigen Computerspieler dann im :t[Wettkampfsystem]{#contest} einsendet,
+Wie man den abgabefertigen :t[Computerspieler]{#player} dann im :t[Wettkampfsystem]{#contest} einsendet,
 ist unter [Wettkampfsystem>Computerspieler](/glossary/contest#computerspieler) beschrieben.
 
 ## Java
 
-Diese Anleitung beschreibt, wie man für den Java-SimpleClient vorgehen muss.
+Diese Anleitung beschreibt, wie man für den Java-Zufallsspieler vorgehen muss.
 
 Hierzu gibt es zwei Möglichkeiten: 
 Die Jar-Datei selbst erstellen oder die Verwendung von Gradle (empfohlen).
@@ -29,7 +29,7 @@ Die Jar-Datei selbst erstellen oder die Verwendung von Gradle (empfohlen).
     "Runnable JAR file" wählen
 
 2.  Im nächsten Fenster wird die "Run Configuration" ausgewählt (dazu
-    muss der SimpleClient mindestens einmal mit Eclipse gestartet worden
+    muss der Zufallsspieler mindestens einmal mit Eclipse gestartet worden
     sein). Darunter wird mit "Browse" die Zieldatei (z.B.
     `[…​]/my_player.jar`) ausgewählt. Bei "Library handling" am besten
     die erste Option nehmen. So wird eine einzige JAR Datei erzeugt, in
@@ -38,8 +38,8 @@ Die Jar-Datei selbst erstellen oder die Verwendung von Gradle (empfohlen).
     operation repacks referenced libraries", den man mit "OK" bestätigen
     muss.
 
-Wenn alles geklappt hat, wurde der Computerspieler in ein auführbares
-Programm überführt. Damit der Wettkampfserver den Client verarbeiten
+Wenn alles geklappt hat, wurde der :t[Computerspieler]{#player} in ein auführbares
+Programm überführt. Damit der Wettkampfserver den :t[Computerspieler]{#player} verarbeiten
 kann, muss er noch in ein ZIP-Archiv gepackt werden (auch wenn ein JAR
 technisch gesehen bereits ein ZIP-Archiv ist).
 
@@ -59,8 +59,8 @@ Archiv kann dann hochegeladen werden.
 
 ### Zweite Möglichkeit - Das ANT Script
 
-Man kann auch das dem SimpleClient beiliegende Ant Buildscript benutzen.
-Dieses kompiliert den SimpleClient und erzeugt automatisch eine JAR
+Man kann auch das dem Zufallsspieler beiliegende Ant Buildscript benutzen.
+Dieses kompiliert den Zufallsspieler und erzeugt automatisch eine JAR
 Datei sowie ein ZIP-Archiv, das man direkt im Websystem hochladen kann.
 
 #### Direkt ausführen
@@ -68,7 +68,7 @@ Datei sowie ein ZIP-Archiv, das man direkt im Websystem hochladen kann.
 Wenn Ant installiert ist, kann man über die Kommandozeile in das
 Verzeichnis des SimpleClients wechseln und mit dem Aufruf "Ant" den
 Build ausführen. Am Ende sollte die Meldung "BUILD SUCCESSFUL"
-erscheinen. Im SimpleClient Ordner findet man dann im Unterordner
+erscheinen. Im Zufallsspieler Ordner findet man dann im Unterordner
 "build" die JAR Datei im Ordner "jar" sowie die fertig gepackte
 ZIP-Datei im Ordner "zipped" die direkt im :t[Wettkampfsystem]{#contest} hochgeladen
 werden kann.
@@ -85,7 +85,7 @@ Eclipse kann von Haus aus auch mit Ant-Scripten umgehen.
 
 3.  Auf der rechten Seite muss man nun das Buildfile auswählen. Das geht
     entweder mit "Browse Workspace" oder "Browse File System". Das
-    Buildfile heißt "build.xml" und liegt direkt in dem SimpleClient
+    Buildfile heißt "build.xml" und liegt direkt in dem Zufallsspieler
     Ordner, den man auf der Software-Challenge Homepage heruntergeladen
     hat. Anschließend mit "Apply" bestätigen und das Fenster schließen
 
@@ -95,7 +95,7 @@ Eclipse kann von Haus aus auch mit Ant-Scripten umgehen.
 
 Am Ende erhält man die Meldung "BUILD SUCCESSFUL".
 
-Im SimpleClient-Ordner findet man dann im Unterordner "build" die JAR
+Im Zufallsspieler-Ordner findet man dann im Unterordner "build" die JAR
 Datei im Ordner "jar" sowie die fertig gepackte ZIP-Datei im Ordner
 "zipped", die direkt ins :t[Wettkampfsystem]{#contest} hochgeladen werden kann.
 
@@ -119,7 +119,7 @@ Shebang-Zeile zu schreiben:
     # encoding: UTF-8
 
 Ein vollständiges Beispiel für einen abgabefertigen Ruby-Computerspieler
-gibt es im [example Verzeichnis des Client-Gems bei
+gibt es im [example Verzeichnis des Computerspieler-Gems bei
 Github](https://github.com/software-challenge/client-ruby/tree/main/example).
 Packt man die beiden Dateien `client.rb` und `main.rb` in ein
 ZIP-Archiv, hat man einen abgabefertigen Computerspieler. Beim Hochladen
@@ -148,7 +148,7 @@ Wettkampfystem als Hauptdatei ausgewählt werden.
 Beachten Sie hierbei, dass diesem Script vom :t[Wettkampfsystem]{#contest} Parameter
 übergeben werden, die an Ihr Programm weitergegeben werden müssen. Diese
 Parameter sind mindestens Host und Port des Spielservers sowie die
-Reservierungsnummer des Spiels, dem der Computerspieler beitreten soll.
+Reservierungsnummer des Spiels, dem der :t[Computerspieler]{#player} beitreten soll.
 Ein Aufruf sieht also in etwa wie folgt aus (falls `start.sh` als
 Hauptdatei eingestellt ist):
 
@@ -192,7 +192,7 @@ Andere Kodierungen führen zu Fehlern bei der Ausführung auf dem Server.
 In Notepad++ kann die Kodierung einfach in dem Tab `Kodierung` angepasst
 werden, die Zeilenenden in `Bearbeiten > Format Zeilenende`.
 
-Bei compilierten Sprachen müssen die Computerspieler für 64bit Linux
+Bei compilierten Sprachen müssen die :t[Computerspieler]{#player} für 64bit Linux
 compiliert werden, bei interpretierten Sprachen muss ein passender
 Interpreter auf dem :t[Wettkampfsystem]{#contest} vorhanden sein. Weiterhin müssen
 Abhängigkeiten wie z.B. genutzte Bibliotheken vorhanden sein oder

--- a/hyperbook/book/entwicklung/einrichtung-der-entwicklungsumgebung.md
+++ b/hyperbook/book/entwicklung/einrichtung-der-entwicklungsumgebung.md
@@ -14,11 +14,11 @@ IntelliJ.
 **Hinweis:** Bevor man sich um die Einrichtung der Entwicklungsumgebung
 kümmert, muss unbedingt [Java installiert](installation-von-java) sein.
 
-## SimpleClient beschaffen
+## Zufallsspieler beschaffen
 
-Der SimpleClient ist schon ein fertiger Computerspieler. Denn Quellcode
+Der Zufallsspieler ist schon ein fertiger Computerspieler. Denn Quellcode
 kann man verwenden, um seinen eigenen Spieler zu programmieren. Den
-SimpleClient bekommt man im 
+Zufallsspieler bekommt man im 
 [Downloadbereich der Software-Challenge](https://software-challenge.de/dokumentation-und-material).
 Man braucht die Version
 *als Quellcode*.
@@ -31,9 +31,9 @@ Am einfachsten ist die Installation von Eclipse mittels des Eclipse
 Installer. Dies ist auf folgender Seite erklärt:
 <https://www.eclipse.org/downloads/packages/installer>
 
-### SimpleClient in Eclipse einbinden
+### Zufallsspieler in Eclipse einbinden
 
-![SimpleClient in Eclipse importieren](/images/eclipse_import_project.jpg)
+![Zufallsspieler in Eclipse importieren](/images/eclipse_import_project.jpg)
 
 1.  Im Menü auf "File" → "Import…" gehen
 
@@ -41,7 +41,7 @@ Installer. Dies ist auf folgender Seite erklärt:
     wählen, dann auf den "Next" Button klicken
 
 3.  Oben rechts auf "Archive…" klicken und die heruntergeladene
-    ZIP-Datei mit dem SimpleClient auswählen. Dann auf "Finish" klicken.
+    ZIP-Datei mit dem Zufallsspieler auswählen. Dann auf "Finish" klicken.
 
 Nun muss noch das SDK und Spiel-Plugin eingebunden werden, damit
 Funktionen wie Autovervollständigung und Anzeige der Dokumentation
@@ -53,7 +53,7 @@ richtig arbeiten:
 2.  Links "Java Source Attachment" auswählen
 
 3.  Rechts "Workspace location" aktivieren und den Pfad zu
-    "sdk-sources.jar" (im Ordner "lib" des SimpleClient Quellcode
+    "sdk-sources.jar" (im Ordner "lib" des Zufallsspieler Quellcode
     Paketes) einstellen
 
 4.  Den Dialog mit "Apply and Close" schließen
@@ -65,20 +65,20 @@ richtig arbeiten:
 6.  Links "Java Source Attachment" auswählen
 
 7.  Rechts "Workspace location" aktivieren und den Pfad zur Source-Jar
-    (im Ordner "lib" des SimpleClient Quellcode Paketes) einstellen
+    (im Ordner "lib" des Zufallsspieler Quellcode Paketes) einstellen
     (heißt genau wie das Spiel-Plugin mit einem "sources" angehängt,
     also z.B. "piranhas\_2019-sources.jar")
 
 8.  Den Dialog mit "Apply and Close" schließen
 
-### SimpleClient aus Eclipse starten
+### Zufallsspieler aus Eclipse starten
 
-Den SimpleClient kann man starten, indem man im Project-Explorer einen
+Den Zufallsspieler kann man starten, indem man im Project-Explorer einen
 Rechtsklick auf die Datei `Starter.java` macht und dann "Run As" → "Java
 Application" auswählt.
 
-**Hinweis:** Damit der SimpleClient erfolgreich startet, muss der
-Spielleiter laufen und auf eine Verbindung warten.
+**Hinweis:** Damit der Zufallsspieler erfolgreich startet, muss der
+:t[Spielleiter]{#server} laufen und auf eine Verbindung warten.
 
 ## Weiterführende Links
 

--- a/hyperbook/book/entwicklung/index.md
+++ b/hyperbook/book/entwicklung/index.md
@@ -11,7 +11,7 @@ die den Start mit der Entwicklung erleichtern soll.
 
 ## Die richtige Programmiersprache
 
-Am einfachsten ist es natürlich den Java/Ruby Simple-Client als Basis zu nutzen,
+Am einfachsten ist es natürlich den Java/Ruby Zufallsspieler als Basis zu nutzen,
 allerdings könnt ihr auch eigene Clients in anderen Sprachen schreiben.
 Das ist mit mehr Arbeit verbunden,
 aber wenn ihr eine Sprache besonders gerne nutzt oder Vorteile seht,
@@ -20,18 +20,18 @@ dann kann es sich lohnen!
 Wenn ihr also genug Erfahrung habt und euch entscheidet den schwereren Weg zu gehen,
 dann solltet ihr euch die [XML-Dokumentation](/spiele/penguins/xml) genau anschauen,
 da ihr die ganze Kommunikation,
-sowie das Parsen der XML Nachrichten, implementieren müsst.
+sowie das Parsen der :t[XML]{#xml} Nachrichten, implementieren müsst.
 Außerdem solltet ihr euch als Beispiel
-den (inoffiziellen) [Swift Client](https://github.com/matthesjh/sc20-swift-client) ansehen.
+den (inoffiziellen) [Swift Computerspieler](https://github.com/matthesjh/sc20-swift-client) ansehen.
 Das kann auch helfen, wenn man Swift nicht kann,
 da die meisten prozeduralen Programmiersprachen viele Ähnlichkeiten haben.
 Somit sollte es nicht allzu schwer sein den Swift code in eure Sprache zu übersetzen.
 Auf ähnliche Weise können natürlich auch
-[der Java Client source code](https://github.com/software-challenge/backend/tree/main/player/src)
-und [der C# Client source code](https://github.com/niklasCarstensen/socha-client-csharp) helfen.
+[der Java :t[Computerspieler]{#player} source code](https://github.com/software-challenge/backend/tree/main/player/src)
+und [der C# :t[Computerspieler]{#player} source code](https://github.com/niklasCarstensen/socha-client-csharp) helfen.
 
 Am besten sprecht ihr die Verwendung einer anderen Programmiersprache frühzeitig mit eurem Tutor ab,
-damit sichergestellt ist, dass der Computerspieler auch am Wettkampf teilnehmen kann.
+damit sichergestellt ist, dass der :t[Computerspieler]{#player} auch am Wettkampf teilnehmen kann.
 Wir stellen gern eine passende Laufzeitumgebung auf dem :t[Wettkampfsystem]{#contest}
 für die Programmiersprache zur Verfügung.
 

--- a/hyperbook/book/entwicklung/simpleclient-erweitern.md
+++ b/hyperbook/book/entwicklung/simpleclient-erweitern.md
@@ -1,9 +1,9 @@
 ---
-name: SimpleClient erweitern
+name: Zufallsspieler erweitern
 index: 7
 ---
 
-# Den SimpleClient erweitern
+# Den Zufallsspieler erweitern
 
 In der Version des Java SimpleClients von der Software-Challenge
 Homepage ist bereits eine Strategie implementiert, die RandomLogic. Man
@@ -11,7 +11,7 @@ kann jedoch auch noch beliebig viele eigene Strategien hinzufügen.
 
 ## Erstellen einer neuen Strategie
 
-Die einfachste Möglichkeit ist, die Klasse `Logic` des SimpleClient zu
+Die einfachste Möglichkeit ist, die Klasse `Logic` des Zufallsspieler zu
 kopieren und umzubenennen (alle Vorkommen von `Logic` durch den neuen
 Klassennamen ersetzen). Der Vollständigkeit halber hier noch das
 Vorgehen bei einer komplett neuen Klasse:

--- a/hyperbook/book/glossar.md
+++ b/hyperbook/book/glossar.md
@@ -5,7 +5,7 @@ index: 10
 
 ## Grundlagen
 
-:t[Einführung in XML]{#xml}
+:t[Einführung-in-XML]{#xml}
 
 ## Spielinfrastruktur
 

--- a/hyperbook/book/index.md
+++ b/hyperbook/book/index.md
@@ -14,12 +14,15 @@ und Erklärungen zur Entwicklung eines eigenen Computerspielers.
 
 Du kannst dir an jeder beliebigen Überschrift ein Lesezeichen setzen,
 was du dann direkt hier auf der Startseite wiederfindest:
-
+:::alert
 ::bookmarks
-
+:::
+---
+:::alert{info}
 ### Beitragen
 
 Wir freuen uns über sämtliche Verbesserungsvorschläge.  
 Die Dokumentation kann direkt auf [GitHub](https://github.com/software-challenge/docs/blob/main/hyperbook/book) editiert werden.
 Alternativ auch gerne per E-Mail an <tech@software-challenge.de> 
 oder als Nachricht im [Discord](https://discord.gg/jhyF7EU).
+:::

--- a/hyperbook/book/spiele/blokus/index.md
+++ b/hyperbook/book/spiele/blokus/index.md
@@ -5,7 +5,7 @@ hide: true
 
 # Spielregeln Blokus: Software-Challenge 2021
 
-Sven Koschnicke &lt;<svk@informatik.uni-kiel.de>&gt;
+ &lt;<tech@software-challenge.de>&gt;
 
 [PDF-Version dieses Dokumentes](regeln.pdf)
 
@@ -80,12 +80,12 @@ Farbe im weiteren Verlauf des Spiels übersprungen (die gelegten Steine
 zählen aber mit in die Wertung). Kann kein Stein irgendeiner Farbe mehr
 gelegt werden, endet das Spiel.
 
-Der Computerspieler hat für das Legen eines Spielsteines zwei Sekunden
+Der :t[Computerspieler]{#player} hat für das Legen eines Spielsteines zwei Sekunden
 Zeit.
 
-Der Spielleiter ruft den Computerspieler nur dann zu einem Zug einer
+Der :t[Spielleiter]{#server} ruft den :t[Computerspieler]{#player} nur dann zu einem Zug einer
 Farbe auf, wenn es auch noch mindestens einen möglichen Zug gibt. Der
-Computerspieler hat dann jedoch auch die Möglichkeit, mit einem
+:t[Computerspieler]{#player} hat dann jedoch auch die Möglichkeit, mit einem
 "Passen"-Zug zu antworten. Dadurch wird die aktuelle Farbe in der
 aktuellen Runde ausgelassen. "Passen" ist erst nach dem ersten Zug
 erlaubt.
@@ -128,23 +128,23 @@ die Datei
 [index.md](https://github.com/software-challenge/docs/blob/master/index.md)
 welche Verweise auf alle Sektionen der Dokumentation enthält) und dann
 auf den Stift oben rechts klicken. Alternativ auch gern eine E-Mail an
-<svk@informatik.uni-kiel.de>.
+<tech@software-challenge.de>.
 
 ## Einleitung
 
-Wie in den letzten Jahren wird zur Client-Server Kommunikation ein
+Wie in den letzten Jahren wird zur Computerspieler-Server Kommunikation ein
 XML-Protokoll genutzt. In diesem Dokument wird die
 Kommunikationsschnittstelle definiert, sodass ein komplett eigener
-Client geschrieben werden kann. Es wird hier nicht die vollständige
+:t[Computerspieler]{#player} geschrieben werden kann. Es wird hier nicht die vollständige
 Kommunikation dokumentiert bzw. definiert, dennoch alles, womit ein
-Client umgehen können muss, um spielfähig zu sein.
+:t[Computerspieler]{#player} umgehen können muss, um spielfähig zu sein.
 
 ### An wen richtet sich dieses Dokument?
 
 Die Kommunikation mit dem Spielserver ist für diejenigen, die aufbauend
 auf dem Simpleclient programmieren, unwichtig. Dort steht bereits ein
-funktionierender Client bereit und es muss nur die Spiellogik entworfen
-werden. Nur wer einen komplett eigenen Client entwerfen will,
+funktionierender :t[Computerspieler]{#player} bereit und es muss nur die Spiellogik entworfen
+werden. Nur wer einen komplett eigenen :t[Computerspieler]{#player} entwerfen will,
 beispielsweise um die Programmiersprache frei wählen zu können, benötigt
 die Definitionen.
 
@@ -154,15 +154,15 @@ Falls Sie beabsichtigen sollten, diese Kommunikationsschnittstelle zu
 realisieren, sei darauf hingewiesen, dass es im Verlauf des Wettbewerbes
 möglich ist, dass weitere, hier noch nicht aufgeführte Elemente zur
 Kommunikationsschnittstelle hinzugefügt werden. Um auch bei solchen
-Änderungen sicher zu sein, dass ihr Client fehlerfrei mit dem Server
-kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des XML jegliche
+Änderungen sicher zu sein, dass ihr :t[Computerspieler]{#player} fehlerfrei mit dem Server
+kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des :t[XML]{#xml} jegliche
 Daten zu verwerfen, die hier nicht weiter definiert sind. Die vom
 Institut bereitgestellten Programme (Server, Simpleclient) nutzen eine
-Bibliothek um Java-Objekte direkt in XML zu konvertieren und umgekehrt.
+Bibliothek um Java-Objekte direkt in :t[XML]{#xml} zu konvertieren und umgekehrt.
 Dabei werden XML-Nachrichten nicht unbedingt mit einer newline
 abgeschlossen.
 
-Die XML Dokumentation behandelt ausschließlich die Kommunikation. Falls
+Die :t[XML]{#xml} Dokumentation behandelt ausschließlich die Kommunikation. Falls
 Sie Dokumentation für den Verbindungsaufbau suchen, so finden Sie diese
 [hier](https://docs.software-challenge.de/_computerspieler_abgabefertig_machen.html#andere-sprache).
 
@@ -216,7 +216,7 @@ gegebenen Platz betreten.
 
 #### Welcome Message
 
-Der Server antwortet darauf erst, wenn der zweite Client ebenfalls
+Der Server antwortet darauf erst, wenn der zweite :t[Computerspieler]{#player} ebenfalls
 verbunden ist:
 
 -   ROOM\_ID Id des GameRooms
@@ -370,7 +370,7 @@ Damit sieht beispielsweise ein Zug so aus:
 
 ## Spielsteine
 
-Es gibt 21 verschiedene Arten Spielsteine. Alle haben im XML einen
+Es gibt 21 verschiedene Arten Spielsteine. Alle haben im :t[XML]{#xml} einen
 Namen. Diese sind:
 
 -   `MONO`
@@ -591,8 +591,8 @@ vor dem ersten Zug.
 
 ### Beispiel kompletter Spielstatus
 
-Hier ist das XML eines kompletten beispielhaften Spielstatus, wie es der
-Computerspieler vom Server bekommt:
+Hier ist das :t[XML]{#xml} eines kompletten beispielhaften Spielstatus, wie es der
+:t[Computerspieler]{#player} vom Server bekommt:
 
     <room roomId="cb3bc426-5c70-48b9-9307-943bc328b503">
       <data class="memento">
@@ -646,7 +646,7 @@ Computerspieler vom Server bekommt:
 
 ## Spiel verlassen
 
-Wenn ein Client den Raum verlässt, bekommen die anderen Clients eine
+Wenn ein :t[Computerspieler]{#player} den Raum verlässt, bekommen die anderen Clients eine
 entsprechende Meldung vom Server.
 
 -   `ROOM_ID` Id des GameRooms
@@ -713,7 +713,7 @@ Spieltyp:
 
 ### Variante 1 (AdminClient [Mit Reservierungscode](#mit-reservierungscode))
 
-Ein Client registriert sich als Administrator mit dem in
+Ein :t[Computerspieler]{#player} registriert sich als Administrator mit dem in
 server.properties festgelegten Passwort pw:
 
     <protocol><authenticate password="pw" />
@@ -912,7 +912,7 @@ Daraufhin wird der erste Spieler aufgefordert einen Zug zu senden:
       <data class="sc.framework.plugins.protocol.MoveRequest" />
     </room>
 
-Der Client des CurrentPlayer sendet nun einen Zug ([ZUG](#zug)):
+Der :t[Computerspieler]{#player} des CurrentPlayer sendet nun einen Zug ([ZUG](#zug)):
 
     <room roomId="cb3bc426-5c70-48b9-9307-943bc328b503">
       <data class="sc.plugin2021.SetMove">

--- a/hyperbook/book/spiele/blokus/spielregeln/content.md
+++ b/hyperbook/book/spiele/blokus/spielregeln/content.md
@@ -56,12 +56,12 @@ Farbe im weiteren Verlauf des Spiels übersprungen (die gelegten Steine
 zählen aber mit in die Wertung). Kann kein Stein irgendeiner Farbe mehr
 gelegt werden, endet das Spiel.
 
-Der Computerspieler hat für das Legen eines Spielsteines zwei Sekunden
+Der :t[Computerspieler]{#player} hat für das Legen eines Spielsteines zwei Sekunden
 Zeit.
 
-Der Spielleiter ruft den Computerspieler nur dann zu einem Zug einer
+Der :t[Spielleiter]{#server} ruft den :t[Computerspieler]{#player} nur dann zu einem Zug einer
 Farbe auf, wenn es auch noch mindestens einen möglichen Zug gibt. Der
-Computerspieler hat dann jedoch auch die Möglichkeit, mit einem
+:t[Computerspieler]{#player} hat dann jedoch auch die Möglichkeit, mit einem
 "Passen"-Zug zu antworten. Dadurch wird die aktuelle Farbe in der
 aktuellen Runde ausgelassen. "Passen" ist erst nach dem ersten Zug
 erlaubt.

--- a/hyperbook/book/spiele/blokus/spielregeln/regeln.md
+++ b/hyperbook/book/spiele/blokus/spielregeln/regeln.md
@@ -71,12 +71,12 @@ Farbe im weiteren Verlauf des Spiels übersprungen (die gelegten Steine
 zählen aber mit in die Wertung). Kann kein Stein irgendeiner Farbe mehr
 gelegt werden, endet das Spiel.
 
-Der Computerspieler hat für das Legen eines Spielsteines zwei Sekunden
+Der :t[Computerspieler]{#player} hat für das Legen eines Spielsteines zwei Sekunden
 Zeit.
 
-Der Spielleiter ruft den Computerspieler nur dann zu einem Zug einer
+Der :t[Spielleiter]{#server} ruft den :t[Computerspieler]{#player} nur dann zu einem Zug einer
 Farbe auf, wenn es auch noch mindestens einen möglichen Zug gibt. Der
-Computerspieler hat dann jedoch auch die Möglichkeit, mit einem
+:t[Computerspieler]{#player} hat dann jedoch auch die Möglichkeit, mit einem
 "Passen"-Zug zu antworten. Dadurch wird die aktuelle Farbe in der
 aktuellen Runde ausgelassen. "Passen" ist erst nach dem ersten Zug
 erlaubt.

--- a/hyperbook/book/spiele/blokus/xml-dokumentation/einleitung-xml.md
+++ b/hyperbook/book/spiele/blokus/xml-dokumentation/einleitung-xml.md
@@ -1,18 +1,18 @@
 # Einleitung
 
-Wie in den letzten Jahren wird zur Client-Server Kommunikation ein
+Wie in den letzten Jahren wird zur Computerspieler-Server Kommunikation ein
 XML-Protokoll genutzt. In diesem Dokument wird die
 Kommunikationsschnittstelle definiert, sodass ein komplett eigener
-Client geschrieben werden kann. Es wird hier nicht die vollständige
+:t[Computerspieler]{#player} geschrieben werden kann. Es wird hier nicht die vollständige
 Kommunikation dokumentiert bzw. definiert, dennoch alles, womit ein
-Client umgehen können muss, um spielfähig zu sein.
+:t[Computerspieler]{#player} umgehen können muss, um spielfähig zu sein.
 
 ## An wen richtet sich dieses Dokument?
 
 Die Kommunikation mit dem Spielserver ist für diejenigen, die aufbauend
 auf dem Simpleclient programmieren, unwichtig. Dort steht bereits ein
-funktionierender Client bereit und es muss nur die Spiellogik entworfen
-werden. Nur wer einen komplett eigenen Client entwerfen will,
+funktionierender :t[Computerspieler]{#player} bereit und es muss nur die Spiellogik entworfen
+werden. Nur wer einen komplett eigenen :t[Computerspieler]{#player} entwerfen will,
 beispielsweise um die Programmiersprache frei wählen zu können, benötigt
 die Definitionen.
 
@@ -22,14 +22,14 @@ Falls Sie beabsichtigen sollten, diese Kommunikationsschnittstelle zu
 realisieren, sei darauf hingewiesen, dass es im Verlauf des Wettbewerbes
 möglich ist, dass weitere, hier noch nicht aufgeführte Elemente zur
 Kommunikationsschnittstelle hinzugefügt werden. Um auch bei solchen
-Änderungen sicher zu sein, dass ihr Client fehlerfrei mit dem Server
-kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des XML jegliche
+Änderungen sicher zu sein, dass ihr :t[Computerspieler]{#player} fehlerfrei mit dem Server
+kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des :t[XML]{#xml} jegliche
 Daten zu verwerfen, die hier nicht weiter definiert sind. Die vom
 Institut bereitgestellten Programme (Server, Simpleclient) nutzen eine
-Bibliothek um Java-Objekte direkt in XML zu konvertieren und umgekehrt.
+Bibliothek um Java-Objekte direkt in :t[XML]{#xml} zu konvertieren und umgekehrt.
 Dabei werden XML-Nachrichten nicht unbedingt mit einer newline
 abgeschlossen.
 
-Die XML Dokumentation behandelt ausschließlich die Kommunikation. Falls
+Die :t[XML]{#xml} Dokumentation behandelt ausschließlich die Kommunikation. Falls
 Sie Dokumentation für den Verbindungsaufbau suchen, so finden Sie diese
 [hier](https://docs.software-challenge.de/_computerspieler_abgabefertig_machen.html#andere-sprache).

--- a/hyperbook/book/spiele/blokus/xml-dokumentation/spiel-betreten.md
+++ b/hyperbook/book/spiele/blokus/xml-dokumentation/spiel-betreten.md
@@ -48,7 +48,7 @@ gegebenen Platz betreten.
 
 ### Welcome Message
 
-Der Server antwortet darauf erst, wenn der zweite Client ebenfalls
+Der Server antwortet darauf erst, wenn der zweite :t[Computerspieler]{#player} ebenfalls
 verbunden ist:
 
 -   ROOM\_ID Id des GameRooms

--- a/hyperbook/book/spiele/blokus/xml-dokumentation/spiel-verlassen.md
+++ b/hyperbook/book/spiele/blokus/xml-dokumentation/spiel-verlassen.md
@@ -1,6 +1,6 @@
 # Spiel verlassen
 
-Wenn ein Client den Raum verlässt, bekommen die anderen Clients eine
+Wenn ein :t[Computerspieler]{#player} den Raum verlässt, bekommen die anderen Clients eine
 entsprechende Meldung vom Server.
 
 -   `ROOM_ID` Id des GameRooms

--- a/hyperbook/book/spiele/blokus/xml-dokumentation/spielstatus.md
+++ b/hyperbook/book/spiele/blokus/xml-dokumentation/spielstatus.md
@@ -174,8 +174,8 @@ vor dem ersten Zug.
 
 ## Beispiel kompletter Spielstatus
 
-Hier ist das XML eines kompletten beispielhaften Spielstatus, wie es der
-Computerspieler vom Server bekommt:
+Hier ist das :t[XML]{#xml} eines kompletten beispielhaften Spielstatus, wie es der
+:t[Computerspieler]{#player} vom Server bekommt:
 
     <room roomId="cb3bc426-5c70-48b9-9307-943bc328b503">
       <data class="memento">

--- a/hyperbook/book/spiele/blokus/xml-dokumentation/spielsteine.md
+++ b/hyperbook/book/spiele/blokus/xml-dokumentation/spielsteine.md
@@ -1,6 +1,6 @@
 # Spielsteine
 
-Es gibt 21 verschiedene Arten Spielsteine. Alle haben im XML einen
+Es gibt 21 verschiedene Arten Spielsteine. Alle haben im :t[XML]{#xml} einen
 Namen. Diese sind:
 
 -   `MONO`

--- a/hyperbook/book/spiele/blokus/xml-dokumentation/spielverlauf.md
+++ b/hyperbook/book/spiele/blokus/xml-dokumentation/spielverlauf.md
@@ -8,7 +8,7 @@ Spieltyp:
 
 ## Variante 1 (AdminClient [???](#mit-reservierungscode))
 
-Ein Client registriert sich als Administrator mit dem in
+Ein :t[Computerspieler]{#player} registriert sich als Administrator mit dem in
 server.properties festgelegten Passwort pw:
 
     <protocol><authenticate password="pw" />
@@ -207,7 +207,7 @@ Daraufhin wird der erste Spieler aufgefordert einen Zug zu senden:
       <data class="sc.framework.plugins.protocol.MoveRequest" />
     </room>
 
-Der Client des CurrentPlayer sendet nun einen Zug ([???](#zug)):
+Der :t[Computerspieler]{#player} des CurrentPlayer sendet nun einen Zug ([???](#zug)):
 
     <room roomId="cb3bc426-5c70-48b9-9307-943bc328b503">
       <data class="sc.plugin2021.SetMove">

--- a/hyperbook/book/spiele/blokus/xml-dokumentation/xml-dokumentation.md
+++ b/hyperbook/book/spiele/blokus/xml-dokumentation/xml-dokumentation.md
@@ -12,23 +12,23 @@ die Datei
 [index.md](https://github.com/software-challenge/docs/blob/master/index.md)
 welche Verweise auf alle Sektionen der Dokumentation enthält) und dann
 auf den Stift oben rechts klicken. Alternativ auch gern eine E-Mail an
-<svk@informatik.uni-kiel.de>.
+<tech@software-challenge.de>.
 
 # Einleitung
 
-Wie in den letzten Jahren wird zur Client-Server Kommunikation ein
+Wie in den letzten Jahren wird zur Computerspieler-Server Kommunikation ein
 XML-Protokoll genutzt. In diesem Dokument wird die
 Kommunikationsschnittstelle definiert, sodass ein komplett eigener
-Client geschrieben werden kann. Es wird hier nicht die vollständige
+:t[Computerspieler]{#player} geschrieben werden kann. Es wird hier nicht die vollständige
 Kommunikation dokumentiert bzw. definiert, dennoch alles, womit ein
-Client umgehen können muss, um spielfähig zu sein.
+:t[Computerspieler]{#player} umgehen können muss, um spielfähig zu sein.
 
 ## An wen richtet sich dieses Dokument?
 
 Die Kommunikation mit dem Spielserver ist für diejenigen, die aufbauend
 auf dem Simpleclient programmieren, unwichtig. Dort steht bereits ein
-funktionierender Client bereit und es muss nur die Spiellogik entworfen
-werden. Nur wer einen komplett eigenen Client entwerfen will,
+funktionierender :t[Computerspieler]{#player} bereit und es muss nur die Spiellogik entworfen
+werden. Nur wer einen komplett eigenen :t[Computerspieler]{#player} entwerfen will,
 beispielsweise um die Programmiersprache frei wählen zu können, benötigt
 die Definitionen.
 
@@ -38,15 +38,15 @@ Falls Sie beabsichtigen sollten, diese Kommunikationsschnittstelle zu
 realisieren, sei darauf hingewiesen, dass es im Verlauf des Wettbewerbes
 möglich ist, dass weitere, hier noch nicht aufgeführte Elemente zur
 Kommunikationsschnittstelle hinzugefügt werden. Um auch bei solchen
-Änderungen sicher zu sein, dass ihr Client fehlerfrei mit dem Server
-kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des XML jegliche
+Änderungen sicher zu sein, dass ihr :t[Computerspieler]{#player} fehlerfrei mit dem Server
+kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des :t[XML]{#xml} jegliche
 Daten zu verwerfen, die hier nicht weiter definiert sind. Die vom
 Institut bereitgestellten Programme (Server, Simpleclient) nutzen eine
-Bibliothek um Java-Objekte direkt in XML zu konvertieren und umgekehrt.
+Bibliothek um Java-Objekte direkt in :t[XML]{#xml} zu konvertieren und umgekehrt.
 Dabei werden XML-Nachrichten nicht unbedingt mit einer newline
 abgeschlossen.
 
-Die XML Dokumentation behandelt ausschließlich die Kommunikation. Falls
+Die :t[XML]{#xml} Dokumentation behandelt ausschließlich die Kommunikation. Falls
 Sie Dokumentation für den Verbindungsaufbau suchen, so finden Sie diese
 [hier](https://docs.software-challenge.de/_computerspieler_abgabefertig_machen.html#andere-sprache).
 
@@ -100,7 +100,7 @@ gegebenen Platz betreten.
 
 ### Welcome Message
 
-Der Server antwortet darauf erst, wenn der zweite Client ebenfalls
+Der Server antwortet darauf erst, wenn der zweite :t[Computerspieler]{#player} ebenfalls
 verbunden ist:
 
 -   ROOM\_ID Id des GameRooms
@@ -254,7 +254,7 @@ Damit sieht beispielsweise ein Zug so aus:
 
 # Spielsteine
 
-Es gibt 21 verschiedene Arten Spielsteine. Alle haben im XML einen
+Es gibt 21 verschiedene Arten Spielsteine. Alle haben im :t[XML]{#xml} einen
 Namen. Diese sind:
 
 -   `MONO`
@@ -475,8 +475,8 @@ vor dem ersten Zug.
 
 ## Beispiel kompletter Spielstatus
 
-Hier ist das XML eines kompletten beispielhaften Spielstatus, wie es der
-Computerspieler vom Server bekommt:
+Hier ist das :t[XML]{#xml} eines kompletten beispielhaften Spielstatus, wie es der
+:t[Computerspieler]{#player} vom Server bekommt:
 
     <room roomId="cb3bc426-5c70-48b9-9307-943bc328b503">
       <data class="memento">
@@ -530,7 +530,7 @@ Computerspieler vom Server bekommt:
 
 # Spiel verlassen
 
-Wenn ein Client den Raum verlässt, bekommen die anderen Clients eine
+Wenn ein :t[Computerspieler]{#player} den Raum verlässt, bekommen die anderen Clients eine
 entsprechende Meldung vom Server.
 
 -   `ROOM_ID` Id des GameRooms
@@ -597,7 +597,7 @@ Spieltyp:
 
 ## Variante 1 (AdminClient [Mit Reservierungscode](#mit-reservierungscode))
 
-Ein Client registriert sich als Administrator mit dem in
+Ein :t[Computerspieler]{#player} registriert sich als Administrator mit dem in
 server.properties festgelegten Passwort pw:
 
     <protocol><authenticate password="pw" />
@@ -796,7 +796,7 @@ Daraufhin wird der erste Spieler aufgefordert einen Zug zu senden:
       <data class="sc.framework.plugins.protocol.MoveRequest" />
     </room>
 
-Der Client des CurrentPlayer sendet nun einen Zug ([ZUG](#zug)):
+Der :t[Computerspieler]{#player} des CurrentPlayer sendet nun einen Zug ([ZUG](#zug)):
 
     <room roomId="cb3bc426-5c70-48b9-9307-943bc328b503">
       <data class="sc.plugin2021.SetMove">

--- a/hyperbook/book/spiele/hase-und-igel/index.md
+++ b/hyperbook/book/spiele/hase-und-igel/index.md
@@ -30,7 +30,7 @@ die Datei
 [index.md](https://github.com/software-challenge/docs/blob/master/index.md)
 welche Verweise auf alle Sektionen der Dokumentation enthält) und dann
 auf den Stift oben rechts klicken. Alternativ auch gern eine E-Mail an
-<svk@informatik.uni-kiel.de>.
+<tech@software-challenge.de>.
 
 ## Spielbeginn
 
@@ -262,23 +262,23 @@ die Datei
 [index.md](https://github.com/software-challenge/docs/blob/master/index.md)
 welche Verweise auf alle Sektionen der Dokumentation enthält) und dann
 auf den Stift oben rechts klicken. Alternativ auch gern eine E-Mail an
-<svk@informatik.uni-kiel.de>.
+<tech@software-challenge.de>.
 
 ## Einleitung
 
-Wie in den letzten Jahren wird zur Client-Server Kommunikation ein
+Wie in den letzten Jahren wird zur Computerspieler-Server Kommunikation ein
 XML-Protokoll genutzt. In diesem Dokument wird die
 Kommunikationsschnittstelle definiert, sodass ein komplett eigener
-Client geschrieben werden kann. Es wird hier nicht die vollständige
+:t[Computerspieler]{#player} geschrieben werden kann. Es wird hier nicht die vollständige
 Kommunikation dokumentiert bzw. definiert, dennoch alles, womit ein
-Client umgehen können muss, um spielfähig zu sein.
+:t[Computerspieler]{#player} umgehen können muss, um spielfähig zu sein.
 
 ### An wen richtet sich dieses Dokument?
 
 Die Kommunikation mit dem Spielserver ist für diejenigen, die aufbauend
 auf dem Simpleclient programmieren, unwichtig. Dort steht bereits ein
-funktionierender Client bereit und es muss nur die Spiellogik entworfen
-werden. \\\\ Nur wer einen komplett eigenen Client entwerfen will,
+funktionierender :t[Computerspieler]{#player} bereit und es muss nur die Spiellogik entworfen
+werden. \\\\ Nur wer einen komplett eigenen :t[Computerspieler]{#player} entwerfen will,
 beispielsweise um die Programmiersprache frei wählen zu können, benötigt
 die Definitionen.
 
@@ -288,11 +288,11 @@ Falls Sie beabsichtigen sollten, diese Kommunikationsschnittstelle zu
 realisieren, sei darauf hingewiesen, dass es im Verlauf des Wettbewerbes
 möglich ist, dass weitere, hier noch nicht aufgeführte Elemente zur
 Kommunikationsschnittstelle hinzugefügt werden. Um auch bei solchen
-Änderungen sicher zu sein, dass ihr Client fehlerfrei mit dem Server
-kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des XML jegliche
+Änderungen sicher zu sein, dass ihr :t[Computerspieler]{#player} fehlerfrei mit dem Server
+kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des :t[XML]{#xml} jegliche
 Daten zu verwerfen, die hier nicht weiter definiert sind. Die vom
 Institut bereitgestellten Programme (Server, Simpleclient) nutzen eine
-Bibliothek um Java-Objekte direkt in XML zu konvertieren und umgekehrt.
+Bibliothek um Java-Objekte direkt in :t[XML]{#xml} zu konvertieren und umgekehrt.
 Dabei werden XML-Nachrichten nicht mit einem newline abgeschlossen.
 
 ## Spiel betreten
@@ -345,7 +345,7 @@ gegebenen Platz betreten.
 
 #### Welcome Message
 
-Der Server antwortet darauf nur, wenn der zweite Client ebenfalls
+Der Server antwortet darauf nur, wenn der zweite :t[Computerspieler]{#player} ebenfalls
 verbunden ist:
 
 -   ROOM\_ID Id des GameRooms
@@ -567,7 +567,7 @@ Eine einfache Nachricht fordert zum Zug auf:
 
 ## Fehler
 
-Ein “spielfähiger” Client muss nicht mit Fehlern umgehen können.
+Ein “spielfähiger” :t[Computerspieler]{#player} muss nicht mit Fehlern umgehen können.
 Fehlerhafte Züge beispielsweise resultieren in einem vorzeitigen Ende
 des Spieles, das im nächsten gesendeten Gamestate erkannt werden kann
 (siehe [Spielergebnis](#spielende)).
@@ -586,7 +586,7 @@ des Spieles, das im nächsten gesendeten Gamestate erkannt werden kann
 
 ## Spiel verlassen
 
-Wenn ein Client den Raum verlässt, bekommen die anderen Clients eine
+Wenn ein :t[Computerspieler]{#player} den Raum verlässt, bekommen die anderen Clients eine
 entsprechende Meldung vom Server.
 
 -   ROOM\_ID Id des GameRooms
@@ -673,7 +673,7 @@ Spieltyp:
 
 ### Variante 1 (AdminClient [Mit Reservierungscode](#mit-reservierungscode))
 
-Ein Client registriert sich als Administrator mit dem in
+Ein :t[Computerspieler]{#player} registriert sich als Administrator mit dem in
 server.properties festgelegten Passwort p:
 
     <protocol><authenticate passphrase="p"/>
@@ -813,7 +813,7 @@ Daraufhin wird der erste Spieler aufgefordert einen Zug zu senden:
       <data class="sc.framework.plugins.protocol.MoveRequest"/>
     </room>
 
-Der Client des CurrentPlayer sendet nun einen Zug ([ZUG](#zug)):
+Der :t[Computerspieler]{#player} des CurrentPlayer sendet nun einen Zug ([ZUG](#zug)):
 
     <room roomId="871faccb-5190-4e44-82fc-6cdcbb493726">
       <data class="move">

--- a/hyperbook/book/spiele/hase-und-igel/spielregeln/regeln.md
+++ b/hyperbook/book/spiele/hase-und-igel/spielregeln/regeln.md
@@ -12,7 +12,7 @@ die Datei
 [index.md](https://github.com/software-challenge/docs/blob/master/index.md)
 welche Verweise auf alle Sektionen der Dokumentation enthält) und dann
 auf den Stift oben rechts klicken. Alternativ auch gern eine E-Mail an
-<svk@informatik.uni-kiel.de>.
+<tech@software-challenge.de>.
 
 # Spielbeginn
 

--- a/hyperbook/book/spiele/hase-und-igel/tutorial/start.md
+++ b/hyperbook/book/spiele/hase-und-igel/tutorial/start.md
@@ -1,9 +1,9 @@
 Am einfachsten ist es die KI auf Grundlage des SimpleClients zu
 schreiben:
 
--   Als erstes muss der SimpleClient heruntergeladen werden
+-   Als erstes muss der Zufallsspieler heruntergeladen werden
     (<http://www.software-challenge.de/downloads/> bitte den
-    SimpleClient als „Quellcode“ downloaden)
+    Zufallsspieler als „Quellcode“ downloaden)
 
 -   Dieser muss nun in Eclips eingebunden werden:
     <https://docs.software-challenge.de/#einrichtung-von-eclipse>
@@ -59,6 +59,6 @@ des SimpleClients.
 
 1.  Arbeite alle anderen Dokumente durch.
 
-2.  Analysiere die Herangehensweise der SimpleClient-KI.
+2.  Analysiere die Herangehensweise der Zufallsspieler-KI.
 
 3.  Schreibe eine KI.

--- a/hyperbook/book/spiele/hase-und-igel/tutorial/tutorial.md
+++ b/hyperbook/book/spiele/hase-und-igel/tutorial/tutorial.md
@@ -5,9 +5,9 @@
 Am einfachsten ist es die KI auf Grundlage des SimpleClients zu
 schreiben:
 
--   Als erstes muss der SimpleClient heruntergeladen werden
+-   Als erstes muss der Zufallsspieler heruntergeladen werden
     (<http://www.software-challenge.de/downloads/> bitte den
-    SimpleClient als „Quellcode“ downloaden)
+    Zufallsspieler als „Quellcode“ downloaden)
 
 -   Dieser muss nun in Eclips eingebunden werden:
     <https://docs.software-challenge.de/#einrichtung-von-eclipse>
@@ -63,7 +63,7 @@ des SimpleClients.
 
 1.  Arbeite alle anderen Dokumente durch.
 
-2.  Analysiere die Herangehensweise der SimpleClient-KI.
+2.  Analysiere die Herangehensweise der Zufallsspieler-KI.
 
 3.  Schreibe eine KI.
 

--- a/hyperbook/book/spiele/hase-und-igel/xml-dokumentation/einleitung-xml.md
+++ b/hyperbook/book/spiele/hase-und-igel/xml-dokumentation/einleitung-xml.md
@@ -1,18 +1,18 @@
 # Einleitung
 
-Wie in den letzten Jahren wird zur Client-Server Kommunikation ein
+Wie in den letzten Jahren wird zur Computerspieler-Server Kommunikation ein
 XML-Protokoll genutzt. In diesem Dokument wird die
 Kommunikationsschnittstelle definiert, sodass ein komplett eigener
-Client geschrieben werden kann. Es wird hier nicht die vollständige
+:t[Computerspieler]{#player} geschrieben werden kann. Es wird hier nicht die vollständige
 Kommunikation dokumentiert bzw. definiert, dennoch alles, womit ein
-Client umgehen können muss, um spielfähig zu sein.
+:t[Computerspieler]{#player} umgehen können muss, um spielfähig zu sein.
 
 ## An wen richtet sich dieses Dokument?
 
 Die Kommunikation mit dem Spielserver ist für diejenigen, die aufbauend
 auf dem Simpleclient programmieren, unwichtig. Dort steht bereits ein
-funktionierender Client bereit und es muss nur die Spiellogik entworfen
-werden. \\\\ Nur wer einen komplett eigenen Client entwerfen will,
+funktionierender :t[Computerspieler]{#player} bereit und es muss nur die Spiellogik entworfen
+werden. \\\\ Nur wer einen komplett eigenen :t[Computerspieler]{#player} entwerfen will,
 beispielsweise um die Programmiersprache frei wählen zu können, benötigt
 die Definitionen.
 
@@ -22,9 +22,9 @@ Falls Sie beabsichtigen sollten, diese Kommunikationsschnittstelle zu
 realisieren, sei darauf hingewiesen, dass es im Verlauf des Wettbewerbes
 möglich ist, dass weitere, hier noch nicht aufgeführte Elemente zur
 Kommunikationsschnittstelle hinzugefügt werden. Um auch bei solchen
-Änderungen sicher zu sein, dass ihr Client fehlerfrei mit dem Server
-kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des XML jegliche
+Änderungen sicher zu sein, dass ihr :t[Computerspieler]{#player} fehlerfrei mit dem Server
+kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des :t[XML]{#xml} jegliche
 Daten zu verwerfen, die hier nicht weiter definiert sind. Die vom
 Institut bereitgestellten Programme (Server, Simpleclient) nutzen eine
-Bibliothek um Java-Objekte direkt in XML zu konvertieren und umgekehrt.
+Bibliothek um Java-Objekte direkt in :t[XML]{#xml} zu konvertieren und umgekehrt.
 Dabei werden XML-Nachrichten nicht mit einem newline abgeschlossen.

--- a/hyperbook/book/spiele/hase-und-igel/xml-dokumentation/fehler.md
+++ b/hyperbook/book/spiele/hase-und-igel/xml-dokumentation/fehler.md
@@ -1,6 +1,6 @@
 # Fehler
 
-Ein “spielfähiger” Client muss nicht mit Fehlern umgehen können.
+Ein “spielfähiger” :t[Computerspieler]{#player} muss nicht mit Fehlern umgehen können.
 Fehlerhafte Züge beispielsweise resultieren in einem vorzeitigen Ende
 des Spieles, das im nächsten gesendeten Gamestate erkannt werden kann
 (siehe [???](#spielende)).

--- a/hyperbook/book/spiele/hase-und-igel/xml-dokumentation/spiel-betreten.md
+++ b/hyperbook/book/spiele/hase-und-igel/xml-dokumentation/spiel-betreten.md
@@ -48,7 +48,7 @@ gegebenen Platz betreten.
 
 ### Welcome Message
 
-Der Server antwortet darauf nur, wenn der zweite Client ebenfalls
+Der Server antwortet darauf nur, wenn der zweite :t[Computerspieler]{#player} ebenfalls
 verbunden ist:
 
 -   ROOM\_ID Id des GameRooms

--- a/hyperbook/book/spiele/hase-und-igel/xml-dokumentation/spiel-verlassen.md
+++ b/hyperbook/book/spiele/hase-und-igel/xml-dokumentation/spiel-verlassen.md
@@ -1,6 +1,6 @@
 # Spiel verlassen
 
-Wenn ein Client den Raum verlässt, bekommen die anderen Clients eine
+Wenn ein :t[Computerspieler]{#player} den Raum verlässt, bekommen die anderen Clients eine
 entsprechende Meldung vom Server.
 
 -   ROOM\_ID Id des GameRooms

--- a/hyperbook/book/spiele/hase-und-igel/xml-dokumentation/spielverlauf.md
+++ b/hyperbook/book/spiele/hase-und-igel/xml-dokumentation/spielverlauf.md
@@ -8,7 +8,7 @@ Spieltyp:
 
 ## Variante 1 (AdminClient [???](#mit-reservierungscode))
 
-Ein Client registriert sich als Administrator mit dem in
+Ein :t[Computerspieler]{#player} registriert sich als Administrator mit dem in
 server.properties festgelegten Passwort p:
 
     <protocol><authenticate passphrase="p"/>
@@ -148,7 +148,7 @@ Daraufhin wird der erste Spieler aufgefordert einen Zug zu senden:
       <data class="sc.framework.plugins.protocol.MoveRequest"/>
     </room>
 
-Der Client des CurrentPlayer sendet nun einen Zug ([???](#zug)):
+Der :t[Computerspieler]{#player} des CurrentPlayer sendet nun einen Zug ([???](#zug)):
 
     <room roomId="871faccb-5190-4e44-82fc-6cdcbb493726">
       <data class="move">

--- a/hyperbook/book/spiele/hase-und-igel/xml-dokumentation/xml-dokumentation.md
+++ b/hyperbook/book/spiele/hase-und-igel/xml-dokumentation/xml-dokumentation.md
@@ -12,23 +12,23 @@ die Datei
 [index.md](https://github.com/software-challenge/docs/blob/master/index.md)
 welche Verweise auf alle Sektionen der Dokumentation enthält) und dann
 auf den Stift oben rechts klicken. Alternativ auch gern eine E-Mail an
-<svk@informatik.uni-kiel.de>.
+<tech@software-challenge.de>.
 
 # Einleitung
 
-Wie in den letzten Jahren wird zur Client-Server Kommunikation ein
+Wie in den letzten Jahren wird zur Computerspieler-Server Kommunikation ein
 XML-Protokoll genutzt. In diesem Dokument wird die
 Kommunikationsschnittstelle definiert, sodass ein komplett eigener
-Client geschrieben werden kann. Es wird hier nicht die vollständige
+:t[Computerspieler]{#player} geschrieben werden kann. Es wird hier nicht die vollständige
 Kommunikation dokumentiert bzw. definiert, dennoch alles, womit ein
-Client umgehen können muss, um spielfähig zu sein.
+:t[Computerspieler]{#player} umgehen können muss, um spielfähig zu sein.
 
 ## An wen richtet sich dieses Dokument?
 
 Die Kommunikation mit dem Spielserver ist für diejenigen, die aufbauend
 auf dem Simpleclient programmieren, unwichtig. Dort steht bereits ein
-funktionierender Client bereit und es muss nur die Spiellogik entworfen
-werden. \\\\ Nur wer einen komplett eigenen Client entwerfen will,
+funktionierender :t[Computerspieler]{#player} bereit und es muss nur die Spiellogik entworfen
+werden. \\\\ Nur wer einen komplett eigenen :t[Computerspieler]{#player} entwerfen will,
 beispielsweise um die Programmiersprache frei wählen zu können, benötigt
 die Definitionen.
 
@@ -38,11 +38,11 @@ Falls Sie beabsichtigen sollten, diese Kommunikationsschnittstelle zu
 realisieren, sei darauf hingewiesen, dass es im Verlauf des Wettbewerbes
 möglich ist, dass weitere, hier noch nicht aufgeführte Elemente zur
 Kommunikationsschnittstelle hinzugefügt werden. Um auch bei solchen
-Änderungen sicher zu sein, dass ihr Client fehlerfrei mit dem Server
-kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des XML jegliche
+Änderungen sicher zu sein, dass ihr :t[Computerspieler]{#player} fehlerfrei mit dem Server
+kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des :t[XML]{#xml} jegliche
 Daten zu verwerfen, die hier nicht weiter definiert sind. Die vom
 Institut bereitgestellten Programme (Server, Simpleclient) nutzen eine
-Bibliothek um Java-Objekte direkt in XML zu konvertieren und umgekehrt.
+Bibliothek um Java-Objekte direkt in :t[XML]{#xml} zu konvertieren und umgekehrt.
 Dabei werden XML-Nachrichten nicht mit einem newline abgeschlossen.
 
 # Spiel betreten
@@ -95,7 +95,7 @@ gegebenen Platz betreten.
 
 ### Welcome Message
 
-Der Server antwortet darauf nur, wenn der zweite Client ebenfalls
+Der Server antwortet darauf nur, wenn der zweite :t[Computerspieler]{#player} ebenfalls
 verbunden ist:
 
 -   ROOM\_ID Id des GameRooms
@@ -317,7 +317,7 @@ Eine einfache Nachricht fordert zum Zug auf:
 
 # Fehler
 
-Ein “spielfähiger” Client muss nicht mit Fehlern umgehen können.
+Ein “spielfähiger” :t[Computerspieler]{#player} muss nicht mit Fehlern umgehen können.
 Fehlerhafte Züge beispielsweise resultieren in einem vorzeitigen Ende
 des Spieles, das im nächsten gesendeten Gamestate erkannt werden kann
 (siehe [Spielergebnis](#spielende)).
@@ -336,7 +336,7 @@ des Spieles, das im nächsten gesendeten Gamestate erkannt werden kann
 
 # Spiel verlassen
 
-Wenn ein Client den Raum verlässt, bekommen die anderen Clients eine
+Wenn ein :t[Computerspieler]{#player} den Raum verlässt, bekommen die anderen Clients eine
 entsprechende Meldung vom Server.
 
 -   ROOM\_ID Id des GameRooms
@@ -423,7 +423,7 @@ Spieltyp:
 
 ## Variante 1 (AdminClient [Mit Reservierungscode](#mit-reservierungscode))
 
-Ein Client registriert sich als Administrator mit dem in
+Ein :t[Computerspieler]{#player} registriert sich als Administrator mit dem in
 server.properties festgelegten Passwort p:
 
     <protocol><authenticate passphrase="p"/>
@@ -563,7 +563,7 @@ Daraufhin wird der erste Spieler aufgefordert einen Zug zu senden:
       <data class="sc.framework.plugins.protocol.MoveRequest"/>
     </room>
 
-Der Client des CurrentPlayer sendet nun einen Zug ([ZUG](#zug)):
+Der :t[Computerspieler]{#player} des CurrentPlayer sendet nun einen Zug ([ZUG](#zug)):
 
     <room roomId="871faccb-5190-4e44-82fc-6cdcbb493726">
       <data class="move">

--- a/hyperbook/book/spiele/hive/xml-dokumentation/einleitung-xml.md
+++ b/hyperbook/book/spiele/hive/xml-dokumentation/einleitung-xml.md
@@ -1,18 +1,18 @@
 # Einleitung
 
-Wie in den letzten Jahren wird zur Client-Server Kommunikation ein
+Wie in den letzten Jahren wird zur Computerspieler-Server Kommunikation ein
 XML-Protokoll genutzt. In diesem Dokument wird die
 Kommunikationsschnittstelle definiert, sodass ein komplett eigener
-Client geschrieben werden kann. Es wird hier nicht die vollständige
+:t[Computerspieler]{#player} geschrieben werden kann. Es wird hier nicht die vollständige
 Kommunikation dokumentiert bzw. definiert, dennoch alles, womit ein
-Client umgehen können muss, um spielfähig zu sein.
+:t[Computerspieler]{#player} umgehen können muss, um spielfähig zu sein.
 
 ## An wen richtet sich dieses Dokument?
 
 Die Kommunikation mit dem Spielserver ist für diejenigen, die aufbauend
 auf dem Simpleclient programmieren, unwichtig. Dort steht bereits ein
-funktionierender Client bereit und es muss nur die Spiellogik entworfen
-werden. Nur wer einen komplett eigenen Client entwerfen will,
+funktionierender :t[Computerspieler]{#player} bereit und es muss nur die Spiellogik entworfen
+werden. Nur wer einen komplett eigenen :t[Computerspieler]{#player} entwerfen will,
 beispielsweise um die Programmiersprache frei wählen zu können, benötigt
 die Definitionen.
 
@@ -22,9 +22,9 @@ Falls Sie beabsichtigen sollten, diese Kommunikationsschnittstelle zu
 realisieren, sei darauf hingewiesen, dass es im Verlauf des Wettbewerbes
 möglich ist, dass weitere, hier noch nicht aufgeführte Elemente zur
 Kommunikationsschnittstelle hinzugefügt werden. Um auch bei solchen
-Änderungen sicher zu sein, dass ihr Client fehlerfrei mit dem Server
-kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des XML jegliche
+Änderungen sicher zu sein, dass ihr :t[Computerspieler]{#player} fehlerfrei mit dem Server
+kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des :t[XML]{#xml} jegliche
 Daten zu verwerfen, die hier nicht weiter definiert sind. Die vom
 Institut bereitgestellten Programme (Server, Simpleclient) nutzen eine
-Bibliothek um Java-Objekte direkt in XML zu konvertieren und umgekehrt.
+Bibliothek um Java-Objekte direkt in :t[XML]{#xml} zu konvertieren und umgekehrt.
 Dabei werden XML-Nachrichten nicht mit einem newline abgeschlossen.

--- a/hyperbook/book/spiele/hive/xml-dokumentation/fehler.md
+++ b/hyperbook/book/spiele/hive/xml-dokumentation/fehler.md
@@ -1,6 +1,6 @@
 # Fehler
 
-Ein “spielfähiger” Client muss nicht mit Fehlern umgehen können.
+Ein “spielfähiger” :t[Computerspieler]{#player} muss nicht mit Fehlern umgehen können.
 Fehlerhafte Züge beispielsweise resultieren in einem vorzeitigen Ende
 des Spieles, das im nächsten gesendeten Gamestate erkannt werden kann
 (siehe [???](#spielende)).

--- a/hyperbook/book/spiele/hive/xml-dokumentation/spiel-betreten.md
+++ b/hyperbook/book/spiele/hive/xml-dokumentation/spiel-betreten.md
@@ -48,7 +48,7 @@ gegebenen Platz betreten.
 
 ### Welcome Message
 
-Der Server antwortet darauf nur, wenn der zweite Client ebenfalls
+Der Server antwortet darauf nur, wenn der zweite :t[Computerspieler]{#player} ebenfalls
 verbunden ist:
 
 -   ROOM\_ID Id des GameRooms

--- a/hyperbook/book/spiele/hive/xml-dokumentation/spiel-verlassen.md
+++ b/hyperbook/book/spiele/hive/xml-dokumentation/spiel-verlassen.md
@@ -1,6 +1,6 @@
 # Spiel verlassen
 
-Wenn ein Client den Raum verlässt, bekommen die anderen Clients eine
+Wenn ein :t[Computerspieler]{#player} den Raum verlässt, bekommen die anderen Clients eine
 entsprechende Meldung vom Server.
 
 -   ROOM\_ID Id des GameRooms

--- a/hyperbook/book/spiele/hive/xml-dokumentation/spielverlauf.md
+++ b/hyperbook/book/spiele/hive/xml-dokumentation/spielverlauf.md
@@ -8,7 +8,7 @@ Spieltyp:
 
 ## Variante 1 (AdminClient [???](#mit-reservierungscode))
 
-Ein Client registriert sich als Administrator mit dem in
+Ein :t[Computerspieler]{#player} registriert sich als Administrator mit dem in
 server.properties festgelegten Passwort p:
 
     <protocol><authenticate password="p" />
@@ -129,7 +129,7 @@ Daraufhin wird der erste Spieler aufgefordert einen Zug zu senden:
       <data class="sc.framework.plugins.protocol.MoveRequest" />
     </room>
 
-Der Client des CurrentPlayer sendet nun einen Zug ([???](#zug)):
+Der :t[Computerspieler]{#player} des CurrentPlayer sendet nun einen Zug ([???](#zug)):
 
     <room roomId="871faccb-5190-4e44-82fc-6cdcbb493726">
       <data class="setmove">

--- a/hyperbook/book/spiele/hive/xml-dokumentation/xml-dokumentation.md
+++ b/hyperbook/book/spiele/hive/xml-dokumentation/xml-dokumentation.md
@@ -12,23 +12,23 @@ die Datei
 [index.md](https://github.com/software-challenge/docs/blob/master/index.md)
 welche Verweise auf alle Sektionen der Dokumentation enthält) und dann
 auf den Stift oben rechts klicken. Alternativ auch gern eine E-Mail an
-<svk@informatik.uni-kiel.de>.
+<tech@software-challenge.de>.
 
 # Einleitung
 
-Wie in den letzten Jahren wird zur Client-Server Kommunikation ein
+Wie in den letzten Jahren wird zur Computerspieler-Server Kommunikation ein
 XML-Protokoll genutzt. In diesem Dokument wird die
 Kommunikationsschnittstelle definiert, sodass ein komplett eigener
-Client geschrieben werden kann. Es wird hier nicht die vollständige
+:t[Computerspieler]{#player} geschrieben werden kann. Es wird hier nicht die vollständige
 Kommunikation dokumentiert bzw. definiert, dennoch alles, womit ein
-Client umgehen können muss, um spielfähig zu sein.
+:t[Computerspieler]{#player} umgehen können muss, um spielfähig zu sein.
 
 ## An wen richtet sich dieses Dokument?
 
 Die Kommunikation mit dem Spielserver ist für diejenigen, die aufbauend
 auf dem Simpleclient programmieren, unwichtig. Dort steht bereits ein
-funktionierender Client bereit und es muss nur die Spiellogik entworfen
-werden. Nur wer einen komplett eigenen Client entwerfen will,
+funktionierender :t[Computerspieler]{#player} bereit und es muss nur die Spiellogik entworfen
+werden. Nur wer einen komplett eigenen :t[Computerspieler]{#player} entwerfen will,
 beispielsweise um die Programmiersprache frei wählen zu können, benötigt
 die Definitionen.
 
@@ -38,11 +38,11 @@ Falls Sie beabsichtigen sollten, diese Kommunikationsschnittstelle zu
 realisieren, sei darauf hingewiesen, dass es im Verlauf des Wettbewerbes
 möglich ist, dass weitere, hier noch nicht aufgeführte Elemente zur
 Kommunikationsschnittstelle hinzugefügt werden. Um auch bei solchen
-Änderungen sicher zu sein, dass ihr Client fehlerfrei mit dem Server
-kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des XML jegliche
+Änderungen sicher zu sein, dass ihr :t[Computerspieler]{#player} fehlerfrei mit dem Server
+kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des :t[XML]{#xml} jegliche
 Daten zu verwerfen, die hier nicht weiter definiert sind. Die vom
 Institut bereitgestellten Programme (Server, Simpleclient) nutzen eine
-Bibliothek um Java-Objekte direkt in XML zu konvertieren und umgekehrt.
+Bibliothek um Java-Objekte direkt in :t[XML]{#xml} zu konvertieren und umgekehrt.
 Dabei werden XML-Nachrichten nicht mit einem newline abgeschlossen. ==
 Spiel betreten Wenn begonnen wird mit dem Server zu kommunizieren, muss
 zuallererst
@@ -93,7 +93,7 @@ gegebenen Platz betreten.
 
 ### Welcome Message
 
-Der Server antwortet darauf nur, wenn der zweite Client ebenfalls
+Der Server antwortet darauf nur, wenn der zweite :t[Computerspieler]{#player} ebenfalls
 verbunden ist:
 
 -   ROOM\_ID Id des GameRooms
@@ -337,7 +337,7 @@ Eine einfache Nachricht fordert zum Zug auf:
 
 # Fehler
 
-Ein “spielfähiger” Client muss nicht mit Fehlern umgehen können.
+Ein “spielfähiger” :t[Computerspieler]{#player} muss nicht mit Fehlern umgehen können.
 Fehlerhafte Züge beispielsweise resultieren in einem vorzeitigen Ende
 des Spieles, das im nächsten gesendeten Gamestate erkannt werden kann
 (siehe [Spielergebnis](#spielende)).
@@ -356,7 +356,7 @@ des Spieles, das im nächsten gesendeten Gamestate erkannt werden kann
 
 # Spiel verlassen
 
-Wenn ein Client den Raum verlässt, bekommen die anderen Clients eine
+Wenn ein :t[Computerspieler]{#player} den Raum verlässt, bekommen die anderen Clients eine
 entsprechende Meldung vom Server.
 
 -   ROOM\_ID Id des GameRooms
@@ -421,7 +421,7 @@ Spieltyp:
 
 ## Variante 1 (AdminClient [Mit Reservierungscode](#mit-reservierungscode))
 
-Ein Client registriert sich als Administrator mit dem in
+Ein :t[Computerspieler]{#player} registriert sich als Administrator mit dem in
 server.properties festgelegten Passwort p:
 
     <protocol><authenticate password="p" />
@@ -542,7 +542,7 @@ Daraufhin wird der erste Spieler aufgefordert einen Zug zu senden:
       <data class="sc.framework.plugins.protocol.MoveRequest" />
     </room>
 
-Der Client des CurrentPlayer sendet nun einen Zug ([ZUG](#zug)):
+Der :t[Computerspieler]{#player} des CurrentPlayer sendet nun einen Zug ([ZUG](#zug)):
 
     <room roomId="871faccb-5190-4e44-82fc-6cdcbb493726">
       <data class="setmove">

--- a/hyperbook/book/spiele/penguins/xml.md
+++ b/hyperbook/book/spiele/penguins/xml.md
@@ -4,146 +4,18 @@ name: XML-Schnittstelle
 
 # Die Schnittstelle zum Server (XML)
 
-Der Spielleiter kommuniziert mit den Computerspielern über eine Netzwerkverbindung. Dadurch ist man aus technischer Sicht komplett flexibel, was die Wahl der Programmiersprache angeht. Die Computerspieler müssen lediglich das Kommunikationsprotokoll erfüllen.
+Der :t[Spielleiter]{#server} kommuniziert mit den Computerspielern über eine Netzwerkverbindung. Dadurch ist man aus technischer Sicht komplett flexibel, was die Wahl der Programmiersprache angeht. Die :t[Computerspieler]{#player} müssen lediglich das Kommunikationsprotokoll erfüllen.
 
-Anfängern wird allerdings davon abgeraten, einen komplett eigenen Client zu schreiben. Es ist deutlich einfacher, auf einem bereitgestellten Simpleclient aufzubauen, da man sich dabei nur um die Strategie und nicht um die Kommunikation kümmern muss. Außerdem wird vom Institut für Informatik die beste Unterstützung für Java/Kotlin geboten.
+Anfängern wird allerdings davon abgeraten, einen komplett eigenen :t[Computerspieler]{#player} zu schreiben. Es ist deutlich einfacher, auf einem bereitgestellten Simpleclient aufzubauen, da man sich dabei nur um die Strategie und nicht um die Kommunikation kümmern muss. Außerdem wird vom Institut für Informatik die beste Unterstützung für Java/Kotlin geboten.
 
 ## Hinweise
 
-Im Verlauf des Wettbewerbes können Elemente zur Kommunikationsschnittstelle hinzugefügt werden, die in dieser Dokumentation nicht aufgeführt sind. Um auch bei solchen Änderungen sicher zu sein, dass ein Client fehlerfrei mit dem Server kommunizieren kann, sollten beim Auslesen des XML jegliche Daten verworfen werden, die hier nicht weiter definiert sind.
+Im Verlauf des Wettbewerbes können Elemente zur Kommunikationsschnittstelle hinzugefügt werden, die in dieser Dokumentation nicht aufgeführt sind. Um auch bei solchen Änderungen sicher zu sein, dass ein :t[Computerspieler]{#player} fehlerfrei mit dem Server kommunizieren kann, sollten beim Auslesen des :t[XML]{#xml} jegliche Daten verworfen werden, die hier nicht weiter definiert sind.
 
 Die bereitgestellten Programme 
 (:t[Server]{#server}, :t[Java-Spieler]{#player}) nutzen eine Bibliothek,
-um Java-Objekte direkt in XML zu konvertieren und umgekehrt.
+um Java-Objekte direkt in :t[XML]{#xml} zu konvertieren und umgekehrt.
 Dabei werden XML-Nachrichten nicht unbedingt mit einem Zeilenumbruch abgeschlossen.
-
-## Einführung in XML
-
-Die Kommunikation zwischen [Spielleiter](https://docs.software-challenge.de/server.html) und [Computerspieler](https://docs.software-challenge.de/der-computerspieler.html) 
-wird mittels XML-Nachrichten realisiert.
-XML ist eine Auszeichnungssprache, d.h eine Sprache,
-die nicht nur die Daten selbst, sondern auch Informationen über die Interpretation oder Bearbeitung liefert.
-Der Vorteil dieser Sprache liegt darin,
-dass sie sowohl vom Computer als auch vom Menschen gut gelesen werden kann.
-Dieser Abschnitt gibt einen Einstieg in die Struktur von XML.
-
-### Tags
-
-Die Grundelemente von XML sind _Tags_. Ein Tag liefert Informationen über die Art der Daten, die verarbeitet werden sollen. In XML wird ein Tag gebildet, indem man den Tagnamen zwischen spitze Klammern setzt. Dabei kennt XML drei verschiedene Tag-Arten:
-
--   Öffnendes Tag: `<Tag>`
-    
--   Schließendes Tag: `</Tag>`
-    
--   Leeres Tag: `<Tag />`
-    
-
-Der Schrägstrich bedeuted, dass das Tag geschlossen wird. Durch den Schrägstrich am Ende wird das soeben geöffnete Tag direkt wieder geschlossen.
-
-Zwischen den öffnenden und schliessenden Tag steht die Information, die mitgeteilt werden soll.
-
-**Hinweis:** XML unterscheidet strikt zwischen Groß- und Kleinschreibung.
-
-#### Bildungsregeln
-
-Die Tags dürfen nicht beliebig in Dokumenten verwendet werden. Es gelten hier die folgenden Regeln:
-
--   Zu jedem öffnenden Tag muss ein schließendes Tag existieren.
-    
--   Man kann Tags ineinander schachteln. Die einzelnen Tags dürfen sich jedoch nicht überkreuzen.
-    
--   Es darf nur ein Root-Tag geben, d.h. es gibt auf oberster Ebene genau ein Tag, in dem alle anderen enthalten sind.
-    
-
-#### Beispiel für korrekte XML-Syntax
-
-```xml
-<addiere>
-    <komplexe_zahl>
-        <realteil>3.5</realteil>
-        <imaginaerteil>4.2</imaginaerteil>
-    </komplexe_zahl>
-    <komplexe_zahl>
-        <realteil>1</realteil>
-        <imaginaerteil>6.9</imaginaerteil>
-    </komplexe_zahl>
-</addiere>
-```
-
-#### Beispiele für fehlerhafte XML-Syntax
-
--   Fehlerhaft, da es mehrere Elemente auf oberster Ebene gibt:
-    
-
-```xml
-<ueberschrift>
-    Beispieldokument
-</ueberschrift>
-<text>
-    Dies ist ein <unterstrichen>Beispieltext</unterstrichen>
-    <absatz />
-    Noch mehr Text
-</text>
-```
-
--   Fehlerhaft, da Tags sich kreuzen:
-    
-
-```xml
-<dokument>
-    <ueberschrift>
-        Beispieldokument
-    </ueberschrift>
-    <text>
-        <kursiv>Dies <unterstrichen>ist </kursiv>ein Beispieltext</unterstrichen>
-        <absatz />
-        Noch mehr Text
-    </text>
-</dokument>
-```
-
-### Attribute
-
-Man kann im Tag auch Attribute einfügen, in denen Informationen übertragen werden:
-
-```xml
-<Tag attribut="wert" />
-```
-
-Auf diese Weise lässt sich das Beispiel mit den komplexen Zahlen etwas übersichtlicher gestalten:
-
-```xml
-<addiere>
-    <komplexe_zahl realteil="3.5" imaginaerteil="4.2" />
-    <komplexe_zahl realteil="1" imaginaerteil="6.9" />
-</addiere>
-```
-
-### Der Header
-
-Wichtig ist auch die erste Zeile in einem XML-Dokument. Aus ihr kann das Computerprogramm erfahren, wie es mit den Daten umzugehen hat (z.B. welcher Zeichensatz benutzt wird). Dieser Header sieht einem Tag sehr ähnlich:
-
-```xml
-<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
-```
-
-Man nennt so ein Tag, auch _Verarbeitungsinformation_.
-
-Theoretisch darf es in einem XML-Dokument mehrere Verarbeitungsinformationen geben, für die Software-Challenge muss man aber nur den Header kennen.
-
-### Kommentare
-
-Man kann in sein XML-Dokument auch Kommentare einfügen, die beim Einlesen dann ignoriert werden:
-
-```xml
-<!-- Ich bin ein XML-Kommentar -->
-```
-
-Es darf beliebig viele solcher Kommentare geben und sie dürfen nur zwischen Tags stehen.
-
-### Weiterführende Informationen
-
--   [Wikipedia-Artikel über XML](https://de.wikipedia.org/wiki/Extensible_Markup_Language)
 
 ## Das Spielprotokoll
 
@@ -191,9 +63,8 @@ Der Server antwortet auf einen erfolgreichen Spielbeitritt mit:
 <joined roomId="ROOM_ID" />
 ```
 
-ROOM_ID
-
-Identifikationscode der Spielpartie
+- **ROOM_ID**
+  - Identifikationscode der Spielpartie
 
 ### Spielverlauf
 
@@ -201,13 +72,11 @@ Identifikationscode der Spielpartie
 
 Der Server eröffnet das Spiel mit einer Begrüßung und dem initialen Spielstatus sobald beide Spieler verbunden sind.
 
-ROOM_ID
+- **ROOM_ID**
+  - Identifikationscode der Spielpartie
 
-Identifikationscode der Spielpartie
-
-TEAMNUMBER
-
-Spielernummer, eg. `ONE`, `TWO`
+- **TEAMNUMBER**
+  - Spielernummer, eg. `ONE`, `TWO`
 
 #### Syntax der Willkommensnachricht
 
@@ -297,19 +166,14 @@ Danach wird die Verbindung geschlossen.
 
 Zum Spielende erhält jeder Spieler das Ergebnis. Es beginnt mit einer `definition`, die die Interpretation der Ergebnisse erklärt. Für jeden Spieler gibt es einen Eintrag in `scores`. Der darin enthaltene `score` schlüsselt sich auf in:
 
-cause
-
-Beitrag des Spielers zum Spielende (`REGULAR`, `LEFT`, `RULE_VIOLATION`, `SOFT_TIMEOUT`, `HARD_TIMEOUT`)
-
-reason
-
-Erklärung zu `cause`
-
-part
-
-Siegpunkte des Spielers (0 verloren, 1 unentschieden, 2 gewonnen) und weitere Punkteinträge entsprechend `definition`
-
-Wenn es einen Sieger gibt, endet es mit einem `winner`-Tag, welches das Gewinner-Team angibt.
+- **cause**
+  - Beitrag des Spielers zum Spielende (`REGULAR`, `LEFT`, `RULE_VIOLATION`, `SOFT_TIMEOUT`, `HARD_TIMEOUT`).
+- **reason**
+  - Erklärung zu `cause`.
+- **part**
+  - Siegpunkte des Spielers (0 verloren, 1 unentschieden, 2 gewonnen) und weitere Punkteinträge entsprechend `definition`.
+- **winner**
+  - Gibt das Gewinner-Team an, wenn es eines gibt.
 
 Hier ein Beispiel:
 
@@ -349,17 +213,17 @@ Hier ein Beispiel:
 
 ## Administration
 
-Mit einem authentifizierten Client kann man den Server steuern.
+Mit einem authentifizierten :t[Computerspieler]{#player} kann man den Server steuern.
 
 ### Verbindungsaufbau
 
-Zuerst muss sich ein Client mit dem entsprechenden Passwort aus `server.properties` authentifizieren:
+Zuerst muss sich ein :t[Computerspieler]{#player} mit dem entsprechenden Passwort aus `server.properties` authentifizieren:
 
 ```xml
 <protocol><authenticate password="examplepassword"/>
 ```
 
-Ein authentifizierter AdminClient wird benachrichtigt, wenn sich ein Client über ein `JoinRoomRequest` verbindet:
+Ein authentifizierter AdminClient wird benachrichtigt, wenn sich ein :t[Computerspieler]{#player} über ein `JoinRoomRequest` verbindet:
 
 ```xml
 <joinedGameRoom roomId=ROOMID playerCount=X />
@@ -408,18 +272,15 @@ Ein AdminClient kann ein Spiel vorbereiten:
 </prepare>
 ```
 
-pluginId
-
-identifiziert das Spiel (für Hey, Danke für dne Fisch: `swc_2023_pengins`)
+- **pluginId**
+  - identifiziert das Spiel (für Hey, Danke für dne Fisch: `swc_2023_pengins`)
 
 ### Servereinstellungen
 
 Die Servereinstellungen liegen in der `server.properties` Datei, die zusammen mit dem Server heruntergeladen wird. In ihr können folgende Werte konfiguriert werden:
 
-password
+- **password**
+  - lokales Administratorpasswort (standardmäßig auf `examplepassword`)
 
-lokales Administratorpasswort (standardmäßig auf `examplepassword`)
-
-paused
-
-ob ein automatisch angelegtes Spiel anfangs pausiert sein soll oder nicht (standardmäßig pausiert)
+- **paused**
+  - ob ein automatisch angelegtes Spiel anfangs pausiert sein soll oder nicht (standardmäßig pausiert)

--- a/hyperbook/book/spiele/piranhas/index.md
+++ b/hyperbook/book/spiele/piranhas/index.md
@@ -5,7 +5,7 @@ hide: true
 
 # Spielregeln Piranhas: Software-Challenge 2019
 
-Sven Koschnicke &lt;<svk@informatik.uni-kiel.de>&gt;
+ &lt;<tech@software-challenge.de>&gt;
 
 Wir freuen uns über sämtliche Verbesserungsvorschläge.  
 Die Dokumentation kann [direkt auf
@@ -110,23 +110,23 @@ die Datei
 [index.md](https://github.com/software-challenge/docs/blob/master/index.md)
 welche Verweise auf alle Sektionen der Dokumentation enthält) und dann
 auf den Stift oben rechts klicken. Alternativ auch gern eine E-Mail an
-<svk@informatik.uni-kiel.de>.
+<tech@software-challenge.de>.
 
 ## Einleitung
 
-Wie in den letzten Jahren wird zur Client-Server Kommunikation ein
+Wie in den letzten Jahren wird zur Computerspieler-Server Kommunikation ein
 XML-Protokoll genutzt. In diesem Dokument wird die
 Kommunikationsschnittstelle definiert, sodass ein komplett eigener
-Client geschrieben werden kann. Es wird hier nicht die vollständige
+:t[Computerspieler]{#player} geschrieben werden kann. Es wird hier nicht die vollständige
 Kommunikation dokumentiert bzw. definiert, dennoch alles, womit ein
-Client umgehen können muss, um spielfähig zu sein.
+:t[Computerspieler]{#player} umgehen können muss, um spielfähig zu sein.
 
 ### An wen richtet sich dieses Dokument?
 
 Die Kommunikation mit dem Spielserver ist für diejenigen, die aufbauend
 auf dem Simpleclient programmieren, unwichtig. Dort steht bereits ein
-funktionierender Client bereit und es muss nur die Spiellogik entworfen
-werden. \\\\ Nur wer einen komplett eigenen Client entwerfen will,
+funktionierender :t[Computerspieler]{#player} bereit und es muss nur die Spiellogik entworfen
+werden. \\\\ Nur wer einen komplett eigenen :t[Computerspieler]{#player} entwerfen will,
 beispielsweise um die Programmiersprache frei wählen zu können, benötigt
 die Definitionen.
 
@@ -136,11 +136,11 @@ Falls Sie beabsichtigen sollten, diese Kommunikationsschnittstelle zu
 realisieren, sei darauf hingewiesen, dass es im Verlauf des Wettbewerbes
 möglich ist, dass weitere, hier noch nicht aufgeführte Elemente zur
 Kommunikationsschnittstelle hinzugefügt werden. Um auch bei solchen
-Änderungen sicher zu sein, dass ihr Client fehlerfrei mit dem Server
-kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des XML jegliche
+Änderungen sicher zu sein, dass ihr :t[Computerspieler]{#player} fehlerfrei mit dem Server
+kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des :t[XML]{#xml} jegliche
 Daten zu verwerfen, die hier nicht weiter definiert sind. Die vom
 Institut bereitgestellten Programme (Server, Simpleclient) nutzen eine
-Bibliothek um Java-Objekte direkt in XML zu konvertieren und umgekehrt.
+Bibliothek um Java-Objekte direkt in :t[XML]{#xml} zu konvertieren und umgekehrt.
 Dabei werden XML-Nachrichten nicht mit einem newline abgeschlossen.
 
 ## Spiel betreten
@@ -193,7 +193,7 @@ gegebenen Platz betreten.
 
 #### Welcome Message
 
-Der Server antwortet darauf nur, wenn der zweite Client ebenfalls
+Der Server antwortet darauf nur, wenn der zweite :t[Computerspieler]{#player} ebenfalls
 verbunden ist:
 
 -   ROOM\_ID Id des GameRooms
@@ -408,7 +408,7 @@ Eine einfache Nachricht fordert zum Zug auf:
 
 ## Fehler
 
-Ein “spielfähiger” Client muss nicht mit Fehlern umgehen können.
+Ein “spielfähiger” :t[Computerspieler]{#player} muss nicht mit Fehlern umgehen können.
 Fehlerhafte Züge beispielsweise resultieren in einem vorzeitigen Ende
 des Spieles, das im nächsten gesendeten Gamestate erkannt werden kann
 (siehe [Spielergebnis](#spielende)).
@@ -427,7 +427,7 @@ des Spieles, das im nächsten gesendeten Gamestate erkannt werden kann
 
 ## Spiel verlassen
 
-Wenn ein Client den Raum verlässt, bekommen die anderen Clients eine
+Wenn ein :t[Computerspieler]{#player} den Raum verlässt, bekommen die anderen Clients eine
 entsprechende Meldung vom Server.
 
 -   ROOM\_ID Id des GameRooms
@@ -492,7 +492,7 @@ Spieltyp:
 
 ### Variante 1 (AdminClient [Mit Reservierungscode](#mit-reservierungscode))
 
-Ein Client registriert sich als Administrator mit dem in
+Ein :t[Computerspieler]{#player} registriert sich als Administrator mit dem in
 server.properties festgelegten Passwort p:
 
     <protocol><authenticate passphrase="p" />
@@ -599,7 +599,7 @@ Daraufhin wird der erste Spieler aufgefordert einen Zug zu senden:
       <data class="sc.framework.plugins.protocol.MoveRequest" />
     </room>
 
-Der Client des CurrentPlayer sendet nun einen Zug ([ZUG](#zug)):
+Der :t[Computerspieler]{#player} des CurrentPlayer sendet nun einen Zug ([ZUG](#zug)):
 
     <room roomId="871faccb-5190-4e44-82fc-6cdcbb493726">
       <data class="move" x="0" y="0" direction="UP" />

--- a/hyperbook/book/spiele/piranhas/xml-dokumentation/einleitung-xml.md
+++ b/hyperbook/book/spiele/piranhas/xml-dokumentation/einleitung-xml.md
@@ -1,18 +1,18 @@
 # Einleitung
 
-Wie in den letzten Jahren wird zur Client-Server Kommunikation ein
+Wie in den letzten Jahren wird zur Computerspieler-Server Kommunikation ein
 XML-Protokoll genutzt. In diesem Dokument wird die
 Kommunikationsschnittstelle definiert, sodass ein komplett eigener
-Client geschrieben werden kann. Es wird hier nicht die vollständige
+:t[Computerspieler]{#player} geschrieben werden kann. Es wird hier nicht die vollständige
 Kommunikation dokumentiert bzw. definiert, dennoch alles, womit ein
-Client umgehen können muss, um spielfähig zu sein.
+:t[Computerspieler]{#player} umgehen können muss, um spielfähig zu sein.
 
 ## An wen richtet sich dieses Dokument?
 
 Die Kommunikation mit dem Spielserver ist für diejenigen, die aufbauend
 auf dem Simpleclient programmieren, unwichtig. Dort steht bereits ein
-funktionierender Client bereit und es muss nur die Spiellogik entworfen
-werden. \\\\ Nur wer einen komplett eigenen Client entwerfen will,
+funktionierender :t[Computerspieler]{#player} bereit und es muss nur die Spiellogik entworfen
+werden. \\\\ Nur wer einen komplett eigenen :t[Computerspieler]{#player} entwerfen will,
 beispielsweise um die Programmiersprache frei wählen zu können, benötigt
 die Definitionen.
 
@@ -22,9 +22,9 @@ Falls Sie beabsichtigen sollten, diese Kommunikationsschnittstelle zu
 realisieren, sei darauf hingewiesen, dass es im Verlauf des Wettbewerbes
 möglich ist, dass weitere, hier noch nicht aufgeführte Elemente zur
 Kommunikationsschnittstelle hinzugefügt werden. Um auch bei solchen
-Änderungen sicher zu sein, dass ihr Client fehlerfrei mit dem Server
-kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des XML jegliche
+Änderungen sicher zu sein, dass ihr :t[Computerspieler]{#player} fehlerfrei mit dem Server
+kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des :t[XML]{#xml} jegliche
 Daten zu verwerfen, die hier nicht weiter definiert sind. Die vom
 Institut bereitgestellten Programme (Server, Simpleclient) nutzen eine
-Bibliothek um Java-Objekte direkt in XML zu konvertieren und umgekehrt.
+Bibliothek um Java-Objekte direkt in :t[XML]{#xml} zu konvertieren und umgekehrt.
 Dabei werden XML-Nachrichten nicht mit einem newline abgeschlossen.

--- a/hyperbook/book/spiele/piranhas/xml-dokumentation/fehler.md
+++ b/hyperbook/book/spiele/piranhas/xml-dokumentation/fehler.md
@@ -1,6 +1,6 @@
 # Fehler
 
-Ein “spielfähiger” Client muss nicht mit Fehlern umgehen können.
+Ein “spielfähiger” :t[Computerspieler]{#player} muss nicht mit Fehlern umgehen können.
 Fehlerhafte Züge beispielsweise resultieren in einem vorzeitigen Ende
 des Spieles, das im nächsten gesendeten Gamestate erkannt werden kann
 (siehe [???](#spielende)).

--- a/hyperbook/book/spiele/piranhas/xml-dokumentation/spiel-betreten.md
+++ b/hyperbook/book/spiele/piranhas/xml-dokumentation/spiel-betreten.md
@@ -48,7 +48,7 @@ gegebenen Platz betreten.
 
 ### Welcome Message
 
-Der Server antwortet darauf nur, wenn der zweite Client ebenfalls
+Der Server antwortet darauf nur, wenn der zweite :t[Computerspieler]{#player} ebenfalls
 verbunden ist:
 
 -   ROOM\_ID Id des GameRooms

--- a/hyperbook/book/spiele/piranhas/xml-dokumentation/spiel-verlassen.md
+++ b/hyperbook/book/spiele/piranhas/xml-dokumentation/spiel-verlassen.md
@@ -1,6 +1,6 @@
 # Spiel verlassen
 
-Wenn ein Client den Raum verlässt, bekommen die anderen Clients eine
+Wenn ein :t[Computerspieler]{#player} den Raum verlässt, bekommen die anderen Clients eine
 entsprechende Meldung vom Server.
 
 -   ROOM\_ID Id des GameRooms

--- a/hyperbook/book/spiele/piranhas/xml-dokumentation/spielverlauf.md
+++ b/hyperbook/book/spiele/piranhas/xml-dokumentation/spielverlauf.md
@@ -8,7 +8,7 @@ Spieltyp:
 
 ## Variante 1 (AdminClient [???](#mit-reservierungscode))
 
-Ein Client registriert sich als Administrator mit dem in
+Ein :t[Computerspieler]{#player} registriert sich als Administrator mit dem in
 server.properties festgelegten Passwort p:
 
     <protocol><authenticate passphrase="p" />
@@ -115,7 +115,7 @@ Daraufhin wird der erste Spieler aufgefordert einen Zug zu senden:
       <data class="sc.framework.plugins.protocol.MoveRequest" />
     </room>
 
-Der Client des CurrentPlayer sendet nun einen Zug ([???](#zug)):
+Der :t[Computerspieler]{#player} des CurrentPlayer sendet nun einen Zug ([???](#zug)):
 
     <room roomId="871faccb-5190-4e44-82fc-6cdcbb493726">
       <data class="move" x="0" y="0" direction="UP" />

--- a/hyperbook/book/spiele/piranhas/xml-dokumentation/xml-dokumentation.md
+++ b/hyperbook/book/spiele/piranhas/xml-dokumentation/xml-dokumentation.md
@@ -12,23 +12,23 @@ die Datei
 [index.md](https://github.com/software-challenge/docs/blob/master/index.md)
 welche Verweise auf alle Sektionen der Dokumentation enthält) und dann
 auf den Stift oben rechts klicken. Alternativ auch gern eine E-Mail an
-<svk@informatik.uni-kiel.de>.
+<tech@software-challenge.de>.
 
 # Einleitung
 
-Wie in den letzten Jahren wird zur Client-Server Kommunikation ein
+Wie in den letzten Jahren wird zur Computerspieler-Server Kommunikation ein
 XML-Protokoll genutzt. In diesem Dokument wird die
 Kommunikationsschnittstelle definiert, sodass ein komplett eigener
-Client geschrieben werden kann. Es wird hier nicht die vollständige
+:t[Computerspieler]{#player} geschrieben werden kann. Es wird hier nicht die vollständige
 Kommunikation dokumentiert bzw. definiert, dennoch alles, womit ein
-Client umgehen können muss, um spielfähig zu sein.
+:t[Computerspieler]{#player} umgehen können muss, um spielfähig zu sein.
 
 ## An wen richtet sich dieses Dokument?
 
 Die Kommunikation mit dem Spielserver ist für diejenigen, die aufbauend
 auf dem Simpleclient programmieren, unwichtig. Dort steht bereits ein
-funktionierender Client bereit und es muss nur die Spiellogik entworfen
-werden. \\\\ Nur wer einen komplett eigenen Client entwerfen will,
+funktionierender :t[Computerspieler]{#player} bereit und es muss nur die Spiellogik entworfen
+werden. \\\\ Nur wer einen komplett eigenen :t[Computerspieler]{#player} entwerfen will,
 beispielsweise um die Programmiersprache frei wählen zu können, benötigt
 die Definitionen.
 
@@ -38,11 +38,11 @@ Falls Sie beabsichtigen sollten, diese Kommunikationsschnittstelle zu
 realisieren, sei darauf hingewiesen, dass es im Verlauf des Wettbewerbes
 möglich ist, dass weitere, hier noch nicht aufgeführte Elemente zur
 Kommunikationsschnittstelle hinzugefügt werden. Um auch bei solchen
-Änderungen sicher zu sein, dass ihr Client fehlerfrei mit dem Server
-kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des XML jegliche
+Änderungen sicher zu sein, dass ihr :t[Computerspieler]{#player} fehlerfrei mit dem Server
+kommunizieren kann, empfehlen wir Ihnen, beim Auslesen des :t[XML]{#xml} jegliche
 Daten zu verwerfen, die hier nicht weiter definiert sind. Die vom
 Institut bereitgestellten Programme (Server, Simpleclient) nutzen eine
-Bibliothek um Java-Objekte direkt in XML zu konvertieren und umgekehrt.
+Bibliothek um Java-Objekte direkt in :t[XML]{#xml} zu konvertieren und umgekehrt.
 Dabei werden XML-Nachrichten nicht mit einem newline abgeschlossen.
 
 # Spiel betreten
@@ -95,7 +95,7 @@ gegebenen Platz betreten.
 
 ### Welcome Message
 
-Der Server antwortet darauf nur, wenn der zweite Client ebenfalls
+Der Server antwortet darauf nur, wenn der zweite :t[Computerspieler]{#player} ebenfalls
 verbunden ist:
 
 -   ROOM\_ID Id des GameRooms
@@ -310,7 +310,7 @@ Eine einfache Nachricht fordert zum Zug auf:
 
 # Fehler
 
-Ein “spielfähiger” Client muss nicht mit Fehlern umgehen können.
+Ein “spielfähiger” :t[Computerspieler]{#player} muss nicht mit Fehlern umgehen können.
 Fehlerhafte Züge beispielsweise resultieren in einem vorzeitigen Ende
 des Spieles, das im nächsten gesendeten Gamestate erkannt werden kann
 (siehe [Spielergebnis](#spielende)).
@@ -329,7 +329,7 @@ des Spieles, das im nächsten gesendeten Gamestate erkannt werden kann
 
 # Spiel verlassen
 
-Wenn ein Client den Raum verlässt, bekommen die anderen Clients eine
+Wenn ein :t[Computerspieler]{#player} den Raum verlässt, bekommen die anderen Clients eine
 entsprechende Meldung vom Server.
 
 -   ROOM\_ID Id des GameRooms
@@ -394,7 +394,7 @@ Spieltyp:
 
 ## Variante 1 (AdminClient [Mit Reservierungscode](#mit-reservierungscode))
 
-Ein Client registriert sich als Administrator mit dem in
+Ein :t[Computerspieler]{#player} registriert sich als Administrator mit dem in
 server.properties festgelegten Passwort p:
 
     <protocol><authenticate passphrase="p" />
@@ -501,7 +501,7 @@ Daraufhin wird der erste Spieler aufgefordert einen Zug zu senden:
       <data class="sc.framework.plugins.protocol.MoveRequest" />
     </room>
 
-Der Client des CurrentPlayer sendet nun einen Zug ([ZUG](#zug)):
+Der :t[Computerspieler]{#player} des CurrentPlayer sendet nun einen Zug ([ZUG](#zug)):
 
     <room roomId="871faccb-5190-4e44-82fc-6cdcbb493726">
       <data class="move" x="0" y="0" direction="UP" />

--- a/hyperbook/glossary/contest.md
+++ b/hyperbook/glossary/contest.md
@@ -6,7 +6,7 @@ index: 3
 # Das Wettkampfsystem
 
 Das Wettkampfsystem ist die Plattform,
-auf der die [Computerspieler](software/client) der einzelnen Schulen gegeneinander antreten.
+auf der die [Computerspieler](glossary/player) der einzelnen Schulen gegeneinander antreten.
 Die Teams können sich dabei nicht nur im Wettkampf,
 sondern auch in Freundschaftsspielen mit ihren Gegnern messen.
 Außerdem liefert es alle Informationen rund um den Wettkampf,
@@ -21,7 +21,7 @@ Die Weboberfläche ist unter der URL
 <http://contest.software-challenge.de> erreichbar. Alle Informationen,
 die den Ablauf des Wettkampfs betreffen (z.B. Terminplan, News oder
 Rangliste) sind auch ohne Anmeldung verfügbar. Man muss sich nur am
-System anmelden, wenn man auf seinen Kurs, bzw. auf seinen Client
+System anmelden, wenn man auf seinen Kurs, bzw. auf seinen Computerspieler
 zugreifen möchte. Im Wettkampfsystem findet die gesamte
 Wettkampfverwaltung statt. Hier können die Clients abgegeben, getestet
 und aktiviert werden und es kann der aktuelle Wettkampfstand abgerufen
@@ -139,7 +139,7 @@ Schüler haben in dieser Hinsicht keinerlei Rechte.
 
 **Hinweis:** Es muss nicht jeder Schüler eingetragen werden und über
 Zugangsdaten erhalten. Es reicht, wenn sich die Teammitglieder am Server
-anmelden können, die den Computerspieler hochladen.
+anmelden können, die den :t[Computerspieler]{#player} hochladen.
 
 Mit den Symbolen neben den Teammitgliedern kann man sich die
 Personendetails anschauen, sie bearbeiten oder das Mitglied aus dem Team
@@ -164,7 +164,7 @@ Optionen:
 -   Ein Spieltag wurde gespielt
 
 -   In einem Ihrer Teams gibt es noch keinen spielbereiten
-    Computerspieler für den nahenden Spieltag
+    :t[Computerspieler]{#player} für den nahenden Spieltag
 
 -   Es gibt Neuigkeiten zum Wettbewerb
 
@@ -172,29 +172,29 @@ Optionen:
 
 #### Computerspieler
 
-In dieser Rubrik kann man die Computerspieler hochladen und verwalten.
-Bevor man einen Computerspieler hochlädt, muss [der Computerspieler abgabefertig gemacht werden](/entwicklung/abgabe).
+In dieser Rubrik kann man die :t[Computerspieler]{#player} hochladen und verwalten.
+Bevor man einen :t[Computerspieler]{#player} hochlädt, muss [der :t[Computerspieler]{#player} abgabefertig gemacht werden](/entwicklung/abgabe).
 
 ![Übersicht der eingesendeten Computerspieler](/images/computerspieler_uebersicht.jpg)
 
 Oben am rechten Rand befindet sich die Schaltfläche, um neue
-Computerspieler hinzuzufügen. Diese führt zu einem Formular, mit dem man
+:t[Computerspieler]{#player} hinzuzufügen. Diese führt zu einem Formular, mit dem man
 das ZIP-Archiv des Computerspielers hochladen kann.
 
 ![Forumlar zum Einsenden eines Computerspielers](/images/computerspieler_hochladen.jpg)
 
 Man kann dem Spieler einen **Namen** geben, damit man ihn in der Liste
 der hochgeladenen Spieler später besser erkennt. Man kann auch noch
-zusätzliche **Parameter** festlegen, die dem Computerspieler beim Start
+zusätzliche **Parameter** festlegen, die dem :t[Computerspieler]{#player} beim Start
 übergeben werden. Dies ist nützlich, wenn der Computerspieler
 verschiedene Spielstrategien unterstützt und man diese per Parameter
-auswählen kann. Dann muss man den Computerspieler nur einmal hochladen
+auswählen kann. Dann muss man den :t[Computerspieler]{#player} nur einmal hochladen
 (die Parameter kann man auch später verändern). Die Angabe eines Namens
 und von Parametern ist optional.
 
 Als letztes muss noch die Umgebung (das **Docker Image**) gewählt
-werden, in der der Computerspieler auf dem Wettkampfsystem ausgeführt
-werden soll. Verwendet der Computerspieler eine der beiden offiziell
+werden, in der der :t[Computerspieler]{#player} auf dem Wettkampfsystem ausgeführt
+werden soll. Verwendet der :t[Computerspieler]{#player} eine der beiden offiziell
 unterstützten Programmiersprachen Java und Ruby, kann hier einfach das
 entsprechende ausgewählt werden. Ansonsten hängt es von der gewählten
 Programmiersprache ab, ob eine passende Umgebung angeboten wird. Sollte
@@ -203,21 +203,21 @@ sich nichts finden, installieren wir gern etwas passendes nach.
 Wurde ein Spieler erfolgreich hochgeladen, befindet er sich in der Liste
 aller Spieler des Teams. Hier kann man mit dem Link "Testen" seine
 Turnierfähigkeit prüfen. Der Spieler spielt dann zweimal gegen den
-SimpleClient. Ein Haken in einem grünen Kreis symbolisiert einen
+Zufallsspieler. Ein Haken in einem grünen Kreis symbolisiert einen
 erfolgreichen Test. Das Logbuch über den Testlauf kann mit dem Link
 "Logs" aufgerufen werden. Unter Umständen muss noch die richtige
 Startdatei eingestellt werden. Dafür kann man rechts in der Spalte
 "Hauptdatei" auf den entsprechenden Link klicken und im folgenden
 Dateimenü die richtige Startdatei auswählen.
 
-Mit dem '+' kann man einen Kommentar an den Client heften, so dass man
+Mit dem '+' kann man einen Kommentar an den :t[Computerspieler]{#player} heften, so dass man
 ihn besser von den anderen unterscheiden kann.
 
 Mit dem Link "Aktivieren" markiert man den Spieler als denjenigen, der
 das nächste Spiel auf dem Wettkampfsystem spielen soll. Dies kann ein
 Freundschaftsspiel oder ein Spiel des Wettkampfes sein.
 
-**Hinweis:** Es nimmt der jeweils aktive Computerspieler am Spieltag
+**Hinweis:** Es nimmt der jeweils aktive :t[Computerspieler]{#player} am Spieltag
 teil. Die Frist für das Aktivieren eines Clients, der an einem Spieltag
 teilnehmen soll, endet am Spieltag um 0 Uhr. Bei späterer Aktivierung
 kann nicht garantiert werden, dass der neue statt des bisherigen Clients

--- a/hyperbook/glossary/player.md
+++ b/hyperbook/glossary/player.md
@@ -22,9 +22,9 @@ da so die :t[XML-Schnittstelle]{#xml} nicht beachtet werden muss.
 Deshalb muss auf den ausführenden Rechnern 
 auch das [Java SDK installiert](entwicklung/installation-von-java) sein.
 
-## Der SimpleClient
+## Der Zufallsspieler
 
-Der SimpleClient ist ein Computerspieler, den das Institut für
+Der Zufallsspieler ist ein Computerspieler, den das Institut für
 Informatik ins Rennen schickt. Er stellt zwar eine korrekte Lösung der
 gestellten Aufgabe dar, ist aber nicht besonders intelligent. Neben dem
 eigentlichen Programm ist auch der Quellcode des SimpleClients
@@ -35,13 +35,13 @@ nicht den ganzen Computerspieler selbst entwickeln, sondern können sich
 auf den Entwurf und die Implementierung ihrer eigenen Strategie
 konzentrieren.
 
-## Der NotSoSimpleClient
+## Der Fortgeschrittener Spieler
 
 Wenn die aktuelle Saison der Software-Challenge etwas weiter
 fortgeschritten ist, stellt das Institut einen stärkeren Computerspieler
-zur Verfügung: den NotSoSimpleClient. Das ist ein Spieler, der eine
-effizientere Strategie zur Lösung der Aufgabe als der SimpleClient
+zur Verfügung: den Fortgeschrittener Spieler. Das ist ein Spieler, der eine
+effizientere Strategie zur Lösung der Aufgabe als der Zufallsspieler
 verfolgt und dadurch nicht mehr so leicht zu schlagen ist. Dieser
 Spieler wird ohne den Quellcode veröffentlicht, so dass die Schüler den
-NotSoSimpleClient zwar als Gegenspieler für Testspiele nehmen, jedoch
+Fortgeschrittener Spieler zwar als Gegenspieler für Testspiele nehmen, jedoch
 nicht den Quellcode für den eigenen Spieler weiterverwenden können.

--- a/hyperbook/glossary/server.md
+++ b/hyperbook/glossary/server.md
@@ -60,11 +60,11 @@ Ein menschlicher Spieler, der über die Programmoberfläche spielt.
 Ein Computerspieler, der im Server integriert ist.
 
     - *Computerspieler, von GUI gestartet*  
-Ein Computerspieler in Form eines separaten Programms, das beim Starten
+Ein :t[Computerspieler]{#player} in Form eines separaten Programms, das beim Starten
 des Spiels automatisch vom Server gestartet wird.
 
-    - *Manuell gestarteter Client*  
-Ein Computerspieler in Form eines separaten Programms, das manuell durch
+    - *Manuell gestarteter Computerspieler*  
+Ein :t[Computerspieler]{#player} in Form eines separaten Programms, das manuell durch
 den Benutzer gestartet werden muss.
 
 Nach Eingabe der erforderlichen Werte kann das Spiel mithilfe des
@@ -110,13 +110,13 @@ einfacherem Wege verfügbar sein.
 
 Wenn ein Fehlerverhalten des Computerspielers nur in einer bestimmten
 Situation in einem Spiel auftritt, kann es oft wünschenswert sein, diese
-Situation erneut nachzuspielen um den Computerspieler gezielt zu
+Situation erneut nachzuspielen um den :t[Computerspieler]{#player} gezielt zu
 verbessern.
 
 Dies ist zur Zeit nur auf etwas kompliziertem Wege möglich. Es folgt
 eine Schritt-für-Schritt Anleitung:
 
-1.  Laden Sie das betreffende Replay aus dem Wettkampfsystem herunter
+1.  Laden Sie das betreffende Replay aus dem :t[Wettkampfsystem]{#contest}herunter
     (.xml.gz Datei).
 
 2.  Entpacken Sie das Replay, sodass sie eine .xml-Datei erhalten.
@@ -125,7 +125,7 @@ eine Schritt-für-Schritt Anleitung:
     den Computerspieler, der für diese Spielsituation getestet werden
     soll. Dieser Spieler muss als Spieler 1 gestartet werden und ist
     dann direkt als erstes dran. Der Gegenspieler kann dann ein
-    beliebiger Computerspieler oder auch ein Mensch sein.
+    beliebiger :t[Computerspieler]{#player} oder auch ein Mensch sein.
 
 4.  Setzen Sie einen Haken bei "Spiel aus Datei laden". Wählen Sie über
     "Datei wählen" das entsprechende Replay aus und spezifizieren sie
@@ -173,18 +173,18 @@ Port 13051. So kannst du ihn nutzen:
 
         java -Dfile.encoding=UTF-8 -Dlogback.configurationFile=logback.xml -jar softwarechallenge-server.jar --port 13051
 
-5.  Starten die Computerspieler in weiteren Kommandozeilenumgebungen auf
-    Port 13051 (beim SimpleClient geht dies mit der Option
-    `--port 13051`). Die Computerspieler verbinden sich automatisch zum
+5.  Starten die :t[Computerspieler]{#player} in weiteren Kommandozeilenumgebungen auf
+    Port 13051 (beim Zufallsspieler geht dies mit der Option
+    `--port 13051`). Die :t[Computerspieler]{#player} verbinden sich automatisch zum
     Testserver und spielen ein Spiel. Danach sollten sich die
-    Computerspieler automatisch beenden.
+    :t[Computerspieler]{#player} automatisch beenden.
 
-6.  Um weitere Testspiele zu spielen, starte die Computerspieler erneut.
+6.  Um weitere Testspiele zu spielen, starte die :t[Computerspieler]{#player} erneut.
     Der Testserver muss dabei nicht neu gestartet werden.
 
 Beachte, dass der Testserver keine Spielaufzeichnungen anlegt, wie es
 der Server mit grafischer Oberfläche tut. Die Auswertung der Spiele muss
-in einem der teilnehmenden Computerspieler geschehen (z.B. durch
+in einem der teilnehmenden :t[Computerspieler]{#player} geschehen (z.B. durch
 Log-Ausgaben).
 
 Es ist ebenfalls möglich, statt eines zufällig generierten vollständigen
@@ -201,14 +201,14 @@ Datei mit dem Argument `--loadGameFile` geladen werden und optional mit
 
 Wenn Sie den Testserver einige Zeit laufen lassen, um eine größere
 Anzahl von Testspielen durchzuführen, kann es dazu kommen, dass
-Computerspieler wegen Zugzeitüberschreitungen vom Server disqualifiziert
+:t[Computerspieler]{#player} wegen Zugzeitüberschreitungen vom Server disqualifiziert
 werden (Soft-Timeout). Dies passiert, obwohl der Zug innerhalb der
 erlaubten Zugzeit (abhängig vom Spiel, bisher aber immer zwei Sekunden)
 an den Server geschickt wurde. Der Garbage Collector der Java Virtual
 Machine löst dieses Verhalten aus. Er pausiert die Anwendung, um nicht
 mehr genutzten Speicher freizugeben. Wenn der Server dadurch zu einem
 ungünstigen Zeitpunkt angehalten wird, bemerkt er den Eingang des Zuges
-vom Computerspieler nicht rechtzeitig und disqualifiziert ihn daraufhin.
+vom :t[Computerspieler]{#player} nicht rechtzeitig und disqualifiziert ihn daraufhin.
 Damit dieses Problem möglichst selten auftritt, haben sich die folgenden
 Parameter beim Starten des Servers bewährt:
 
@@ -250,12 +250,12 @@ Die Konfiguration des Garbage Collectors ist kein Allheilmittel
 und kann zu neuen Problemen führen, auf die man gefasst sein sollte.
 Dazu gehören erhöhter Resourcenverbrauch und Instabilität der Anwendung.
 
-Eine Auflistung möglicher nützlicher Parameter für Computerspieler findet sich unter
+Eine Auflistung möglicher nützlicher Parameter für :t[Computerspieler]{#player} findet sich unter
 https://stackoverflow.com/questions/48989515/java-garbage-collector-time-limit.
 
 ### Massentests
 
-Massentests mit dem eigenen Computerspieler können sehr nützlich sein,
+Massentests mit dem eigenen :t[Computerspieler]{#player} können sehr nützlich sein,
 beispeilsweise um die Stärke gegenüber einer früheren Version zu Testen.
 Dafür wird in jeder Saison ab Version XX.1.0 ein TestClient
 bereitgestellt.
@@ -297,8 +297,8 @@ auf dem selben Port zu starten.
 | Attribut       | Standardwert (Typ)                               | Beschreibung                                                                                                                     |
 | -------------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
 | `--tests`        | 100 (`int`)                                        | Anzahl der Tests, die gespielt werden sollen                                                                                     |
-| `--player1`      | "./defaultplayer.jar" (Dateipfad)                | Erster Computerspieler                                                                                                           |
-| `--player2`      | "./defaultplayer.jar" (Dateipfad)                | Zweiter Computerspieler                                                                                                          |
+| `--player1`      | "./defaultplayer.jar" (Dateipfad)                | Erster :t[Computerspieler]{#player}                                                                                                           |
+| `--player2`      | "./defaultplayer.jar" (Dateipfad)                | Zweiter :t[Computerspieler]{#player}                                                                                                          |
 | `--name1`        | "player1" (`String`)                               | Name des ersten Spielers                                                                                                         |
 | `--name2`        | "player2" (`String`)                               | Name des zweiten Spielers                                                                                                        |
 | `--no-timeout`   | false (`bool`)                                     | Deaktiviere ausscheiden durch Timeouts. Kann durch `--no-timeout1` bzw. `--no-timeout2` für beide Spieler unabhängig gesetzt werden. |

--- a/hyperbook/glossary/xml.md
+++ b/hyperbook/glossary/xml.md
@@ -1,0 +1,127 @@
+## Einführung in XML
+
+Die Kommunikation zwischen [Spielleiter](glossary/server) und [Computerspieler](glossary/player) 
+wird mittels XML-Nachrichten realisiert.
+XML ist eine Auszeichnungssprache, d.h eine Sprache,
+die nicht nur die Daten selbst, sondern auch Informationen über die Interpretation oder Bearbeitung liefert.
+Der Vorteil dieser Sprache liegt darin,
+dass sie sowohl vom Computer als auch vom Menschen gut gelesen werden kann.
+Dieser Abschnitt gibt einen Einstieg in die Struktur von XML.
+
+### Tags
+
+Die Grundelemente von XML sind _Tags_. Ein Tag liefert Informationen über die Art der Daten, die verarbeitet werden sollen. In XML wird ein Tag gebildet, indem man den Tagnamen zwischen spitze Klammern setzt. Dabei kennt XML drei verschiedene Tag-Arten:
+
+-   Öffnendes Tag: `<Tag>`
+    
+-   Schließendes Tag: `</Tag>`
+    
+-   Leeres Tag: `<Tag />`
+    
+
+Der Schrägstrich bedeuted, dass das Tag geschlossen wird. Durch den Schrägstrich am Ende wird das soeben geöffnete Tag direkt wieder geschlossen.
+
+Zwischen den öffnenden und schliessenden Tag steht die Information, die mitgeteilt werden soll.
+
+**Hinweis:** XML unterscheidet strikt zwischen Groß- und Kleinschreibung.
+
+#### Bildungsregeln
+
+Die Tags dürfen nicht beliebig in Dokumenten verwendet werden. Es gelten hier die folgenden Regeln:
+
+-   Zu jedem öffnenden Tag muss ein schließendes Tag existieren.
+    
+-   Man kann Tags ineinander schachteln. Die einzelnen Tags dürfen sich jedoch nicht überkreuzen.
+    
+-   Es darf nur ein Root-Tag geben, d.h. es gibt auf oberster Ebene genau ein Tag, in dem alle anderen enthalten sind.
+    
+
+#### Beispiel für korrekte XML-Syntax
+
+```xml
+<addiere>
+    <komplexe_zahl>
+        <realteil>3.5</realteil>
+        <imaginaerteil>4.2</imaginaerteil>
+    </komplexe_zahl>
+    <komplexe_zahl>
+        <realteil>1</realteil>
+        <imaginaerteil>6.9</imaginaerteil>
+    </komplexe_zahl>
+</addiere>
+```
+
+#### Beispiele für fehlerhafte XML-Syntax
+
+-   Fehlerhaft, da es mehrere Elemente auf oberster Ebene gibt:
+    
+
+```xml
+<ueberschrift>
+    Beispieldokument
+</ueberschrift>
+<text>
+    Dies ist ein <unterstrichen>Beispieltext</unterstrichen>
+    <absatz />
+    Noch mehr Text
+</text>
+```
+
+-   Fehlerhaft, da Tags sich kreuzen:
+    
+
+```xml
+<dokument>
+    <ueberschrift>
+        Beispieldokument
+    </ueberschrift>
+    <text>
+        <kursiv>Dies <unterstrichen>ist </kursiv>ein Beispieltext</unterstrichen>
+        <absatz />
+        Noch mehr Text
+    </text>
+</dokument>
+```
+
+### Attribute
+
+Man kann im Tag auch Attribute einfügen, in denen Informationen übertragen werden:
+
+```xml
+<Tag attribut="wert" />
+```
+
+Auf diese Weise lässt sich das Beispiel mit den komplexen Zahlen etwas übersichtlicher gestalten:
+
+```xml
+<addiere>
+    <komplexe_zahl realteil="3.5" imaginaerteil="4.2" />
+    <komplexe_zahl realteil="1" imaginaerteil="6.9" />
+</addiere>
+```
+
+### Der Header
+
+Wichtig ist auch die erste Zeile in einem XML-Dokument. Aus ihr kann das Computerprogramm erfahren, wie es mit den Daten umzugehen hat (z.B. welcher Zeichensatz benutzt wird). Dieser Header sieht einem Tag sehr ähnlich:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+```
+
+Man nennt so ein Tag, auch _Verarbeitungsinformation_.
+
+Theoretisch darf es in einem XML-Dokument mehrere Verarbeitungsinformationen geben, für die Software-Challenge muss man aber nur den Header kennen.
+
+### Kommentare
+
+Man kann in sein XML-Dokument auch Kommentare einfügen, die beim Einlesen dann ignoriert werden:
+
+```xml
+<!-- Ich bin ein XML-Kommentar -->
+```
+
+Es darf beliebig viele solcher Kommentare geben und sie dürfen nur zwischen Tags stehen.
+
+### Weiterführende Informationen
+
+-   [Wikipedia-Artikel über XML](https://de.wikipedia.org/wiki/Extensible_Markup_Language)

--- a/hyperbook/hyperbook.json
+++ b/hyperbook/hyperbook.json
@@ -8,7 +8,7 @@
     "url": "https://software-challenge.de"
   },
   "language": "de",
-  "repo": "https://github.com/software-challenge/docs",
+  "repo": "https://github.com/software-challenge/docs/tree/main/hyperbook",
   "logo": "/logo.svg",
   "colors":{
     "brand": "#3276AD"


### PR DESCRIPTION
hyperbook: Replaced all names, so that the new standard should apply. Added everywhere the glossary entry link if possible. The terms in the XML documentation were not tables, however they were a little off so I have now aligned them. They should now be more recognizable. I have added the alert feature of hyperbook in the start page. I think this is now more structured.