### PR TITLE
Documentation update

### DIFF
--- a/hyperbook/book/entwicklung/Anleitung-Abgabe.md
+++ b/hyperbook/book/entwicklung/Anleitung-Abgabe.md
@@ -1,0 +1,41 @@
+---
+name: Anleitung für Abgabe
+index: 10
+---
+
+# Computerspieler abgabefertig machen (Anleitung für Export aus der IDE für Java)
+
+Im folgenden findet ihr eine Anleitung wie man seinen fertigen Client aus seiner Entwicklungsumgebung exportieren kann, um ihn im Wettkampfsystem hochladen zu könen.
+
+## Grundsätzliches
+Der Export des Projektes funktioniert für Java bei unserem Projekt über Gradle. Hierbei verwenden wird die Gradle Task "shadowJar". Wie genau das aussieht wird für Eclipse und IntelliJ im Folgenden beschrieben. 
+
+## Eclipse
+Um den Export in Eclipse durchzuführen, muss man die Übersicht der Gradle Tasks öffnen. Um dies zu tun gibt es zwei Wege:
+
+1. Man kann die Übersicht öffnen, in dem man auf das Gradle-Symbol (Elephant) klickt. Dieses Symbol findet man am linken Rand. Es kann sein, dass das Symbol im Darkmode sehr schwer zu erkennen ist.
+
+2. Wenn man die Übersicht nicht finden kann oder das Symbol nicht existiert, kann man die Übersicht öffnen, in dem man oben auf Window/Show view/Other.../Gradle/Gradle Tasks geht und dann einen Doppelklick darauf macht oder es auswählt und unten auf "open" geht.
+</br></br>
+   
+Wenn man nun die Gradle Tasks offen hat, tut mam folgendes:
+1. Man geht auf dem Ordner mit dem Namen des Projekts. Dieser ist standardmäßig "player-Spielkürzel-src"
+2. Unter dem nun angezeigten Inhalt ist ein Ordner der "shadow" heißt, den man nun öffnet
+3. In dem Ordner "shadow" befindet sich eine Task, die shadowJar heißt. Wenn man dort nun einen Doppelklick drauf macht wird das Projekt in Form eines "Executable Jar File" exportiert.
+
+Der Export wird in dem Ordner des Projektes gespeichert. Der Name dieser Jar ist standardmäßig auf "Spielkürzel_Jahreszahl_client" kann aber nach dem Export beliebig geändert werden. Man kann den Namen auch vor dem Export anpassen, wenn man in dem Projekt "build.gradle.kts" öffnet und unter "tasks.shadowJar" den "archiveBaseName" ändert.
+
+## IntelliJ
+Um den Export in IntelliJ durchzuführen, muss man die Übersicht der Gradle Tasks öffnen. Dies geschieht, in dem man auf das Gradle-Symbol (Elephant) am rechten Rand klickt. Nun kann man die Gradle Task unterschiedlich ausführen. Im folgenden werden beide Varianten erläutert:
+
+1. Die kurze Variante über die Konsole:
+   1. Man klickt auf das Konsolen-Symbol (Execute Gradle Task)
+   2. In der offenen Konsole gibt man nun "shadowJar" ein
+   3. Man druckt auf Enter
+
+2. Die lange Variante
+   1. Man geht auf dem Ordner mit dem Namen des Projekts. Dieser ist standardmäßig "player-Spielkürzel-src"
+   2. Unter dem nun angezeigten Inhalt ist ein Ordner der "shadow" heißt, den man nun öffnet
+   3. In dem Ordner "shadow" befindet sich eine Task, die shadowJar heißt. Wenn man dort nun einen Doppelklick drauf macht wird das Projekt in Form eines "Executable Jar File" exportiert.
+
+Der Export wird in dem Ordner des Projektes gespeichert. Der Name dieser Jar ist standardmäßig auf "Spielkürzel_Jahreszahl_client" kann aber nach dem Export beliebig geändert werden. Man kann den Namen auch vor dem Export anpassen, wenn man in dem Projekt "build.gradle.kts" öffnet und unter "tasks.shadowJar" den "archiveBaseName" ändert.

--- a/hyperbook/book/entwicklung/Anleitung-Abgabe.md
+++ b/hyperbook/book/entwicklung/Anleitung-Abgabe.md
@@ -5,34 +5,58 @@ index: 10
 
 # Computerspieler abgabefertig machen (Anleitung für Export aus der IDE für Java)
 
-Im folgenden findet ihr eine Anleitung wie man seinen fertigen Client aus seiner Entwicklungsumgebung exportieren kann, um ihn im Wettkampfsystem hochladen zu könen.
+Im folgenden findet ihr eine Anleitung wie man seinen 
+fertigen Client aus seiner Entwicklungsumgebung exportieren 
+kann, um ihn im Wettkampfsystem hochladen zu könen.
 
 ## Grundsätzliches
-Der Export des Projektes funktioniert für Java bei unserem Projekt über Gradle. Hierbei verwenden wird die Gradle Task "shadowJar". </br>
-
+Der Export des Projektes funktioniert für Java bei unserem Projekt 
+über Gradle. Hierbei wird die Gradle Task "shadowJar" verwendet. </br>
 Wie genau das aussieht wird für Eclipse und IntelliJ im Folgenden beschrieben. 
 
 ## Eclipse
-Um den Export in Eclipse durchzuführen, muss man die Übersicht der Gradle Tasks öffnen. Um dies zu tun gibt es zwei Wege:
+Um den Export in Eclipse durchzuführen, muss man die Übersicht 
+der Gradle Tasks öffnen. Um dies zu tun gibt es zwei Wege:
 
-1. Der erste Weg, wie die Übersicht geöffnet werden kann, ist in dem man auf das Gradle-Symbol (Elephant) klickt. Dieses Symbol ist am linken Rand zu finden. Es kann sein, dass das Symbol im Darkmode sehr schwer zu erkennen ist.
+1. Der erste Weg, wie die Übersicht geöffnet werden kann, ist in 
+   dem man auf das Gradle-Symbol (Elephant) klickt. 
+   Dieses Symbol ist am linken Rand zu finden. Es kann sein, 
+   dass das Symbol im Darkmode sehr schwer zu erkennen ist.
 
-2. Wenn man die Übersicht nicht finden kann oder das Symbol nicht existiert, kann die Übersicht geöffnet, in dem man oben auf Window/Show view/Other.../Gradle/Gradle Tasks geht und dann einen Doppelklick darauf macht oder es auswählt und unten auf "open" klickt.
+2. Wenn man die Übersicht nicht finden kann oder das Symbol nicht existiert, 
+   kann die Übersicht geöffnet werden, in dem man oben auf 
+   Window/Show view/Other.../Gradle/Gradle Tasks geht und dann einen 
+   Doppelklick darauf macht oder es auswählt und unten auf "open" klickt.
 </br></br>
    
 Wenn die Gradle Tasks geöffnet sind, müssen folgende Schritte ausgeführt werden:
-1. Man geht auf den Ordner mit dem Namen des Projekts. Dieser ist standardmäßig "player-Spielkürzel-src"
-   >Falls dort ein X an der Datei zu finden ist, müssen die Gradle Tasks einmal neugeladen werden. </br>
-      Dies geschiet durch den Button "Refresh Tasks for all Projects"
+1. Man geht auf den Ordner mit dem Namen des Projekts. Dieser ist standardmäßig 
+   "player-Spielkürzel-src"
 
-2. Unter dem nun angezeigten Inhalt ist ein Ordner der "shadow" heißt, den man nun öffnet
+   >Falls dort ein X an der Datei zu finden ist, müssen die Gradle Tasks einmal 
+    neugeladen werden. </br> Dies geschiet durch den Button "Refresh Tasks for 
+    all Projects"
 
-3. In dem Ordner "shadow" befindet sich eine Task, die shadowJar heißt. Wenn nun Doppelklick auf die Task macht wird das Projekt in Form eines "Executable Jar File" exportiert.
+2. Unter dem nun angezeigten Inhalt ist ein Ordner 
+   der "shadow" heißt, den man nun öffnet
 
-Der Export wird in dem Ordner des Projektes gespeichert. Der Name dieser Jar ist standardmäßig auf "Spielkürzel_Jahreszahl_client" kann aber nach dem Export beliebig geändert werden. Man kann den Namen auch vor dem Export anpassen, wenn man in dem Projekt "build.gradle.kts" öffnet und unter "tasks.shadowJar" den "archiveBaseName" ändert.
+3. In dem Ordner "shadow" befindet sich eine Task, die shadowJar heißt. 
+   Wenn nun Doppelklick auf die Task macht wird das Projekt in Form eines 
+   "Executable Jar File" exportiert.
+
+
+Der Export wird in dem Ordner des Projektes gespeichert. Der Name dieser Jar 
+ist standardmäßig auf "Spielkürzel_Jahreszahl_client" kann aber nach dem Export 
+beliebig geändert werden. Man kann den Namen auch vor dem Export anpassen, 
+wenn man in dem Projekt "build.gradle.kts" öffnet und unter 
+"tasks.shadowJar" den "archiveBaseName" ändert.
+
 
 ## IntelliJ
-Um den Export in IntelliJ durchzuführen, muss man die Übersicht der Gradle Tasks öffnen. Dies geschieht, in dem man auf das Gradle-Symbol (Elephant) am rechten Rand klickt. Nun kann man die Gradle Task unterschiedlich ausführen. Im folgenden werden beide Varianten erläutert:
+Um den Export in IntelliJ durchzuführen, muss man die Übersicht der Gradle Tasks öffnen. 
+Dies geschieht, in dem man auf das Gradle-Symbol (Elephant) am rechten Rand klickt. 
+Nun kann man die Gradle Task unterschiedlich ausführen. Im folgenden werden 
+beide Varianten erläutert:
 
 1. Die kurze Variante über die Konsole:
    1. Man klickt auf das Konsolen-Symbol (Execute Gradle Task)
@@ -42,6 +66,10 @@ Um den Export in IntelliJ durchzuführen, muss man die Übersicht der Gradle Tas
 2. Die lange Variante
    1. Man geht auf dem Ordner mit dem Namen des Projekts. Dieser ist standardmäßig "player-Spielkürzel-src"
    2. Unter dem nun angezeigten Inhalt ist ein Ordner der "shadow" heißt, den man nun öffnet
-   3. In dem Ordner "shadow" befindet sich eine Task, die shadowJar heißt. Wenn man dort nun einen Doppelklick drauf macht wird das Projekt in Form eines "Executable Jar File" exportiert.
+   3. In dem Ordner "shadow" befindet sich eine Task, die shadowJar heißt. Wenn man dort nun einen
+      Doppelklick drauf macht wird das Projekt in Form eines "Executable Jar File" exportiert.
 
-Der Export wird in dem Ordner des Projektes gespeichert. Der Name dieser Jar ist standardmäßig auf "Spielkürzel_Jahreszahl_client" kann aber nach dem Export beliebig geändert werden. Man kann den Namen auch vor dem Export anpassen, wenn man in dem Projekt "build.gradle.kts" öffnet und unter "tasks.shadowJar" den "archiveBaseName" ändert.
+Der Export wird in dem Ordner des Projektes gespeichert. Der Name dieser Jar ist
+ standardmäßig auf "Spielkürzel_Jahreszahl_client" kann aber nach dem Export beliebig 
+ geändert werden. Man kann den Namen auch vor dem Export anpassen, wenn man in dem Projekt 
+ "build.gradle.kts" öffnet und unter "tasks.shadowJar" den "archiveBaseName" ändert.

--- a/hyperbook/book/entwicklung/Anleitung-Abgabe.md
+++ b/hyperbook/book/entwicklung/Anleitung-Abgabe.md
@@ -5,71 +5,74 @@ index: 10
 
 # Computerspieler abgabefertig machen (Anleitung für Export aus der IDE für Java)
 
-Im folgenden findet ihr eine Anleitung wie man seinen 
-fertigen Client aus seiner Entwicklungsumgebung exportieren 
-kann, um ihn im Wettkampfsystem hochladen zu könen.
+Im folgenden findet ihr eine Anleitung, 
+für den Export eures Computerspielers aus der Entwicklungsumgebung,
+um ihn i Wettkampfsystem hochzuladen.
 
 ## Grundsätzliches
-Der Export des Projektes funktioniert für Java bei unserem Projekt 
-über Gradle. Hierbei wird die Gradle Task "shadowJar" verwendet. </br>
+Der Export des Projektes funktioniert für Java bei unserem Projekt über Gradle. 
+Hierbei wird die Gradle Task "shadowJar" verwendet. </br>
 Wie genau das aussieht wird für Eclipse und IntelliJ im Folgenden beschrieben. 
 
 ## Eclipse
-Um den Export in Eclipse durchzuführen, muss man die Übersicht 
-der Gradle Tasks öffnen. Um dies zu tun gibt es zwei Wege:
+Um den Export in Eclipse durchzuführen, 
+muss man die Übersicht der Gradle Tasks öffnen. 
+Um dies zu tun gibt es zwei Wege:
 
-1. Der erste Weg, wie die Übersicht geöffnet werden kann, ist in 
-   dem man auf das Gradle-Symbol (Elephant) klickt. 
-   Dieses Symbol ist am linken Rand zu finden. Es kann sein, 
-   dass das Symbol im Darkmode sehr schwer zu erkennen ist.
+1. Der erste Weg, die Übersicht zu Öffnen, 
+   ist das Gradle-Symbol (Elephant) am linken Rand. 
+   Es kann sein, dass das Symbol im dunklen Modus schwer zu erkennen ist.
 
-2. Wenn man die Übersicht nicht finden kann oder das Symbol nicht existiert, 
-   kann die Übersicht geöffnet werden, in dem man oben auf 
-   Window/Show view/Other.../Gradle/Gradle Tasks geht und dann einen 
-   Doppelklick darauf macht oder es auswählt und unten auf "open" klickt.
-</br></br>
+2. Ist das Symbol nicht auffindbar, 
+   kann die Übersicht auch geöffnet werden, 
+   in dem man oben auf Window/Show view/Other.../Gradle/Gradle Tasks geht 
+   und dann einen Doppelklick darauf macht oder es auswählt und unten auf "open" klickt.
+   </br></br>
    
 Wenn die Gradle Tasks geöffnet sind, müssen folgende Schritte ausgeführt werden:
-1. Man geht auf den Ordner mit dem Namen des Projekts. Dieser ist standardmäßig 
-   "player-Spielkürzel-src"
+1. Öffne den Ordner mit dem Namen des Projekts.
+   Dieser ist standardmäßig "player-*Spielkürzel*-src"
 
-   >Falls dort ein X an der Datei zu finden ist, müssen die Gradle Tasks einmal 
-    neugeladen werden. </br> Dies geschiet durch den Button "Refresh Tasks for 
-    all Projects"
+   >Falls dort ein X an dem Ordner ist, müssen die Gradle Tasks einmal 
+    neugeladen werden. </br> Dies geschieht durch den Button "Refresh Tasks for 
+    all Projects" (Rechts oben am Fensterrand)
 
-2. Unter dem nun angezeigten Inhalt ist ein Ordner 
-   der "shadow" heißt, den man nun öffnet
+2. Öffne den Ordner mit dem Namen "shadow"
 
 3. In dem Ordner "shadow" befindet sich eine Task, die shadowJar heißt. 
-   Wenn nun Doppelklick auf die Task macht wird das Projekt in Form eines 
-   "Executable Jar File" exportiert.
+   Durch einen Doppelklick wird der Export gestartet.
 
 
-Der Export wird in dem Ordner des Projektes gespeichert. Der Name dieser Jar 
-ist standardmäßig auf "Spielkürzel_Jahreszahl_client" kann aber nach dem Export 
-beliebig geändert werden. Man kann den Namen auch vor dem Export anpassen, 
-wenn man in dem Projekt "build.gradle.kts" öffnet und unter 
-"tasks.shadowJar" den "archiveBaseName" ändert.
+Der Export wird in dem Ordner des Projektes gespeichert. 
+Der Name dieser Jar ist standardmäßig auf "Spielkürzel_Jahreszahl_client" kann 
+aber nach dem Export beliebig geändert werden. 
+Man kann den Namen auch vor dem Export anpassen, 
+wenn man in dem Projekt "build.gradle.kts" öffnet 
+und unter "tasks.shadowJar" den "archiveBaseName" ändert.
 
 
 ## IntelliJ
-Um den Export in IntelliJ durchzuführen, muss man die Übersicht der Gradle Tasks öffnen. 
+Um den Export in IntelliJ durchzuführen, 
+muss man die Übersicht der Gradle Tasks öffnen. 
 Dies geschieht, in dem man auf das Gradle-Symbol (Elephant) am rechten Rand klickt. 
-Nun kann man die Gradle Task unterschiedlich ausführen. Im folgenden werden 
-beide Varianten erläutert:
+Nun kann die Gradle Task unterschiedlich ausgeführt werden. 
+Im folgenden werden beide Varianten erläutert:
 
 1. Die kurze Variante über die Konsole:
-   1. Man klickt auf das Konsolen-Symbol (Execute Gradle Task)
+   1. Klick auf das Konsolen-Symbol (Execute Gradle Task)
    2. In der offenen Konsole gibt man nun "shadowJar" ein
-   3. Man druckt auf Enter
+   3. Man drückt auf Enter
 
 2. Die lange Variante
-   1. Man geht auf dem Ordner mit dem Namen des Projekts. Dieser ist standardmäßig "player-Spielkürzel-src"
-   2. Unter dem nun angezeigten Inhalt ist ein Ordner der "shadow" heißt, den man nun öffnet
-   3. In dem Ordner "shadow" befindet sich eine Task, die shadowJar heißt. Wenn man dort nun einen
-      Doppelklick drauf macht wird das Projekt in Form eines "Executable Jar File" exportiert.
+   1. Man geht auf dem Ordner mit dem Namen des Projekts. 
+      Dieser ist standardmäßig "player-Spielkürzel-src"
+   2. Unter dem nun angezeigten Inhalt öffnet man den Ordner "shadow".
+   3. In dem Ordner "shadow" befindet sich eine Task, die shadowJar heißt. 
+      Durch einen Doppelklick wird der Export gestartet.
 
-Der Export wird in dem Ordner des Projektes gespeichert. Der Name dieser Jar ist
- standardmäßig auf "Spielkürzel_Jahreszahl_client" kann aber nach dem Export beliebig 
- geändert werden. Man kann den Namen auch vor dem Export anpassen, wenn man in dem Projekt 
- "build.gradle.kts" öffnet und unter "tasks.shadowJar" den "archiveBaseName" ändert.
+Der Export wird in dem Ordner des Projektes gespeichert.
+Der Name dieser Jar ist standardmäßig auf "Spielkürzel_Jahreszahl_client", 
+kann aber nach dem Export beliebig geändert werden. 
+Der Namen kann auch vor dem Export anpassen, 
+wenn man in dem Projekt "build.gradle.kts" öffnet 
+und unter "tasks.shadowJar" den "archiveBaseName" ändert.

--- a/hyperbook/book/entwicklung/Anleitung-Abgabe.md
+++ b/hyperbook/book/entwicklung/Anleitung-Abgabe.md
@@ -8,20 +8,26 @@ index: 10
 Im folgenden findet ihr eine Anleitung wie man seinen fertigen Client aus seiner Entwicklungsumgebung exportieren kann, um ihn im Wettkampfsystem hochladen zu könen.
 
 ## Grundsätzliches
-Der Export des Projektes funktioniert für Java bei unserem Projekt über Gradle. Hierbei verwenden wird die Gradle Task "shadowJar". Wie genau das aussieht wird für Eclipse und IntelliJ im Folgenden beschrieben. 
+Der Export des Projektes funktioniert für Java bei unserem Projekt über Gradle. Hierbei verwenden wird die Gradle Task "shadowJar". </br>
+
+Wie genau das aussieht wird für Eclipse und IntelliJ im Folgenden beschrieben. 
 
 ## Eclipse
 Um den Export in Eclipse durchzuführen, muss man die Übersicht der Gradle Tasks öffnen. Um dies zu tun gibt es zwei Wege:
 
-1. Man kann die Übersicht öffnen, in dem man auf das Gradle-Symbol (Elephant) klickt. Dieses Symbol findet man am linken Rand. Es kann sein, dass das Symbol im Darkmode sehr schwer zu erkennen ist.
+1. Der erste Weg, wie die Übersicht geöffnet werden kann, ist in dem man auf das Gradle-Symbol (Elephant) klickt. Dieses Symbol ist am linken Rand zu finden. Es kann sein, dass das Symbol im Darkmode sehr schwer zu erkennen ist.
 
-2. Wenn man die Übersicht nicht finden kann oder das Symbol nicht existiert, kann man die Übersicht öffnen, in dem man oben auf Window/Show view/Other.../Gradle/Gradle Tasks geht und dann einen Doppelklick darauf macht oder es auswählt und unten auf "open" geht.
+2. Wenn man die Übersicht nicht finden kann oder das Symbol nicht existiert, kann die Übersicht geöffnet, in dem man oben auf Window/Show view/Other.../Gradle/Gradle Tasks geht und dann einen Doppelklick darauf macht oder es auswählt und unten auf "open" klickt.
 </br></br>
    
-Wenn man nun die Gradle Tasks offen hat, tut mam folgendes:
-1. Man geht auf dem Ordner mit dem Namen des Projekts. Dieser ist standardmäßig "player-Spielkürzel-src"
+Wenn die Gradle Tasks geöffnet sind, müssen folgende Schritte ausgeführt werden:
+1. Man geht auf den Ordner mit dem Namen des Projekts. Dieser ist standardmäßig "player-Spielkürzel-src"
+   >Falls dort ein X an der Datei zu finden ist, müssen die Gradle Tasks einmal neugeladen werden. </br>
+      Dies geschiet durch den Button "Refresh Tasks for all Projects"
+
 2. Unter dem nun angezeigten Inhalt ist ein Ordner der "shadow" heißt, den man nun öffnet
-3. In dem Ordner "shadow" befindet sich eine Task, die shadowJar heißt. Wenn man dort nun einen Doppelklick drauf macht wird das Projekt in Form eines "Executable Jar File" exportiert.
+
+3. In dem Ordner "shadow" befindet sich eine Task, die shadowJar heißt. Wenn nun Doppelklick auf die Task macht wird das Projekt in Form eines "Executable Jar File" exportiert.
 
 Der Export wird in dem Ordner des Projektes gespeichert. Der Name dieser Jar ist standardmäßig auf "Spielkürzel_Jahreszahl_client" kann aber nach dem Export beliebig geändert werden. Man kann den Namen auch vor dem Export anpassen, wenn man in dem Projekt "build.gradle.kts" öffnet und unter "tasks.shadowJar" den "archiveBaseName" ändert.
 

--- a/hyperbook/book/entwicklung/abgabe.md
+++ b/hyperbook/book/entwicklung/abgabe.md
@@ -9,7 +9,7 @@ Damit das :t[Wettkampfsystem]{#contest} mit dem :t[Computerspieler]{#player} arb
 muss er als ausführbares Programm in ein ZIP-Archiv verpackt werden.
 
 Je nach Programmiersprache, in der der Spieler entwickelt wurde,
-sind unterschiedliche Schritte notwendig.
+sind unterschiedliche Schritte notwendig. Für Java siehe [hier](Anleitung-Abgabe.md).
 
 :::alert{info}
 In der Regel enthält die Spielervorlage alle nötigen Instruktionen zum Packen.

--- a/hyperbook/book/entwicklung/abgabe.md
+++ b/hyperbook/book/entwicklung/abgabe.md
@@ -9,7 +9,8 @@ Damit das :t[Wettkampfsystem]{#contest} mit dem :t[Computerspieler]{#player} arb
 muss er als ausführbares Programm in ein ZIP-Archiv verpackt werden.
 
 Je nach Programmiersprache, in der der Spieler entwickelt wurde,
-sind unterschiedliche Schritte notwendig. </br> Für Java siehe [hier](Anleitung-Abgabe.md).
+sind unterschiedliche Schritte notwendig. </br> 
+Für Java siehe [hier](Anleitung-Abgabe.md).
 
 :::alert{info}
 In der Regel enthält die Spielervorlage alle nötigen Instruktionen zum Packen.

--- a/hyperbook/book/entwicklung/abgabe.md
+++ b/hyperbook/book/entwicklung/abgabe.md
@@ -9,7 +9,7 @@ Damit das :t[Wettkampfsystem]{#contest} mit dem :t[Computerspieler]{#player} arb
 muss er als ausführbares Programm in ein ZIP-Archiv verpackt werden.
 
 Je nach Programmiersprache, in der der Spieler entwickelt wurde,
-sind unterschiedliche Schritte notwendig. Für Java siehe [hier](Anleitung-Abgabe.md).
+sind unterschiedliche Schritte notwendig. </br> Für Java siehe [hier](Anleitung-Abgabe.md).
 
 :::alert{info}
 In der Regel enthält die Spielervorlage alle nötigen Instruktionen zum Packen.

--- a/hyperbook/book/entwicklung/einrichtung-der-entwicklungsumgebung.md
+++ b/hyperbook/book/entwicklung/einrichtung-der-entwicklungsumgebung.md
@@ -53,9 +53,12 @@ $ sudo snap install eclipse --classic
 
 2.  Die heruntergeladene Zip extrahieren
 
-3.  In dem extrahiertem Ordner die Batchdatei gradlew ausführen. Es kann sein das Windows Defender 
-    etwas dagegen hat, weil die Anwendung versucht Gradle herunterzuladen. Falls dies der Fall sein sollte, auf "weiter Informationen" gehen und auf "trotzdem ausführen" klicken.
-    Wenn alles funktioniert hat, muss in der Datei nun ein neuer Ordner mit dem Namen .gradle erschienen sein
+3.  In dem extrahiertem Ordner die Batchdatei gradlew ausführen. Es kann
+    sein das Windows Defender etwas dagegen hat, weil die Anwendung versucht 
+    Gradle herunterzuladen. Falls dies der Fall sein sollte, auf 
+    "weiter Informationen" gehen und auf "trotzdem ausführen" klicken. Wenn 
+    alles funktioniert hat, muss in der Datei nun ein neuer Ordner mit dem Namen 
+    .gradle erschienen sein
 
 4.  Nun öffnet man Eclipse und geht oben links auf:
     1.  File
@@ -69,12 +72,15 @@ $ sudo snap install eclipse --classic
 6.  Hier muss man einige Dinge beachten:
     1.  Oben links bei "Overide workspace settings" ein Häckchen setzen
     2.  Unter "Gradle distribution" Specific Gradle version auswählen und die Version 6.9.1 angeben
-    3.  Unter "Advanced Options" bei "Java home" nachsehen, ob dort der Ordner des JDK (Java Develobment Kit) angegeben ist
-        und dabei beachten das man nur JDK´s der Versionen 11-15 benutzen kann.
+    3.  Unter "Advanced Options" bei "Java home" nachsehen, ob dort der Ordner des 
+        JDK (Java Develobment Kit) angegeben ist und dabei beachten das man nur 
+        JDK´s der Versionen 11-15 benutzen kann.
     4.  Unten wieder auf "Next>" klicken
 
-7. Dieser Schritt kann einen Moment dauern. Wenn alles erfolgreich war, steht unten in der Konsole "CONFIGURE         SUCCESFUL".
-   Falls es funktioniert hat geht man auf "Finish". Falls nicht überprüft man im Schritt davor die Gradle Version und die Version des JDK, dass angegeben ist
+7. Dieser Schritt kann einen Moment dauern. Wenn alles erfolgreich war,
+    steht unten in der Konsole "CONFIGURE SUCCESFUL". Falls es funktioniert 
+    hat geht man auf "Finish". Falls nicht überprüft man im Schritt davor 
+    die Gradle Version und die Version des JDK, dass angegeben ist
 
 ### Spielervorlage aus Eclipse starten
 
@@ -91,18 +97,21 @@ Damit die Spielervorlage erfolgreich startet, muss der
 
 Um IntelliJ zu installieren befilgt man folgende Schritte:
 
- 1. Man geht auf die [IntelliJ-Website](https://www.jetbrains.com/idea/download/?section=windows) und läd sich IntelliJ Community herunter (Ist unten auf der Website zu finden)
+1. Man geht auf die [IntelliJ-Website](https://www.jetbrains.com/idea/download/?section=windows) 
+    und läd sich IntelliJ Community herunter (Ist unten auf der Website zu finden)
 
- 2. Wenn dies geschehen ist führt man die heruntergeladene .exe Datei aus und es öffnet sich ein Installer
+2. Wenn dies geschehen ist führt man die heruntergeladene .exe Datei
+   aus und es öffnet sich ein Installer
 
- 3. Nachdem man ausgewählt hat wo das Programm gespeichert werden soll, kommt man in ein Menü das Installation Options heißt. Hier wählt man
+3. Nachdem man ausgewählt hat wo das Programm gespeichert werden soll,
+    kommt man in ein Menü das Installation Options heißt. Hier wählt man:
     1. Add "Open Folder as Project"
     2. .java
     3. .gradle 
    
- 4. Im nächsten Menü wählt man Install aus
+4. Im nächsten Menü wählt man Install aus
 
- 5. Wenn der Instalationsprozess fertig ist geht man auf Finish
+5. Wenn der Instalationsprozess fertig ist geht man auf Finish
 
 
 ### Spielervorlage in IntelliJ einbinden
@@ -111,16 +120,23 @@ Um IntelliJ zu installieren befilgt man folgende Schritte:
 
 2. Die heruntergeladene Zip extrahieren
 
-3. Man klickt auf Open (entweder im Startmenü neben New Project oder oben links über das Optionsmenü, wenn man bereits in einem Projekt ist)
+3. Man klickt auf Open (entweder im Startmenü neben New Project oder 
+   oben links über das Optionsmenü, wenn man bereits in einem Projekt ist)
 
 4. Nun wählt man die extrahierte Datei aus und klickt auf "Trust Project"
 
-5. Nach dem Import wählt man unten links das Hammersymbol aus und wenn alles funktioniert hat steht in der Konsole "BUILD SUCCESSFUL". Falls das nicht der Fall sein sollte tut man folgendes:
+5. Nach dem Import wählt man unten links das Hammersymbol aus und wenn 
+   alles funktioniert hat steht in der Konsole "BUILD SUCCESSFUL". Falls 
+   das nicht der Fall sein sollte tut man folgendes:
+
    1. Man geht oben links auf Optionen (Das Symbol mit den 4 Strichen)
-   2. Man geht auf "File" und wählt dort "Project Structure" aus
-   3. Nun wählt man bei "SDK" (Software Devolopment Kit) die Version 15 aus und setzt das "Language Level" auf "SDK Default" ganz oben im Menü
+   2. Klickt auf "File" und wählt dort "Project Structure" aus
+   3. Nun wählt man bei "SDK" (Software Devolopment Kit) die Version 15 
+      aus und setzt das "Language Level"  auf "SDK Default" ganz oben im Menü
    4. Nun geht man auf Apply und schließt das Menü
-   5. Wenn man alle Schritte befolgt hat geht man nun wieder auf das Hammersymbol unten links und klickt auf das Refresh-Symbol bzw. auf "Sync Gradle Project" wenn man mit der Maus auf dem Button ist.
+   5. Wenn man alle Schritte befolgt hat geht man nun wieder auf das Hammersymbol 
+      unten links und klickt auf das Refresh-Symbol bzw. auf "Sync Gradle Project" 
+      wenn man mit der Maus auf dem Button ist.
 
 ## Weiterführende Links
 

--- a/hyperbook/book/entwicklung/einrichtung-der-entwicklungsumgebung.md
+++ b/hyperbook/book/entwicklung/einrichtung-der-entwicklungsumgebung.md
@@ -30,13 +30,13 @@ Man braucht die Version
 Am einfachsten ist die Installation von Eclipse unter Windows mittels des Eclipse Installer. 
 Dies ist auf der [Eclipse-Website](https://www.eclipse.org/downloads/packages/installer) gut erklärt.
 
-#### Debian
+#### Debian (Linux)
 Unter Debian basierenden Distributionen ist die Installation sehr einfach mit `snap`.
 ```shell
 $ sudo snap install eclipse --classic
 ```
 
-#### Arch
+#### Arch (Linux)
 Mit einer Arch-Distribution lässt sich Eclipse ebenso einfach mit `snap` installieren. Allerdings ist oftmals `snap` noch nicht installiert.
 ```shell
 $ sudo pacman -S snapd
@@ -49,41 +49,32 @@ $ sudo snap install eclipse --classic
 
 ![Spielervorlage in Eclipse importieren](/images/eclipse_import_project.jpg)
 
-1.  Im Menü auf "File" → "Import…" gehen
+1.  Spielervorlage herunterladen (von unserer Website unter allgemeine Dokumatation)
 
-2.  Im Dialogfenster unter "General" "Projects from Folder or Archive"
-    wählen, dann auf den "Next" Button klicken
+2.  Die heruntergeladene Zip extrahieren
 
-3.  Oben rechts auf "Archive…" klicken und die heruntergeladene
-    ZIP-Datei mit der Spielervorlage auswählen. Dann auf "Finish" klicken.
+3.  In dem extrahiertem Ordner die Batchdatei gradlew ausführen. Es kann sein das Windows Defender 
+    etwas dagegen hat, weil die Anwendung versucht Gradle herunterzuladen. Falls dies der Fall sein sollte, auf "weiter Informationen" gehen und auf "trotzdem ausführen" klicken.
+    Wenn alles funktioniert hat, muss in der Datei nun ein neuer Ordner mit dem Namen .gradle erschienen sein
 
-Nun muss noch das SDK und Spiel-Plugin eingebunden werden, damit
-Funktionen wie Autovervollständigung und Anzeige der Dokumentation
-richtig arbeiten:
+4.  Nun öffnet man Eclipse und geht oben links auf:
+    1.  File
+    2.  Import...
+    3.  Gradle
+    4.  Existing Gradle Project
+    5.  Next>
+   
+5.  Nun wählt man unter "Project root directory" die extrahierte Datei der Spielervorlage aus und klickt auf "next>"
 
-1.  Im Package Explorer einen Rechtsklick auf den Eintrag sdk.jar unter
-    "Referenced Libraries" machen und Properties wählen
+6.  Hier muss man einige Dinge beachten:
+    1.  Oben links bei "Overide workspace settings" ein Häckchen setzen
+    2.  Unter "Gradle distribution" Specific Gradle version auswählen und die Version 6.9.1 angeben
+    3.  Unter "Advanced Options" bei "Java home" nachsehen, ob dort der Ordner des JDK (Java Develobment Kit) angegeben ist
+        und dabei beachten das man nur JDK´s der Versionen 11-15 benutzen kann.
+    4.  Unten wieder auf "Next>" klicken
 
-2.  Links "Java Source Attachment" auswählen
-
-3.  Rechts "Workspace location" aktivieren und den Pfad zu
-    "sdk-sources.jar" (im Ordner "lib" des Spielervorlagequellcode
-    Paketes) einstellen
-
-4.  Den Dialog mit "Apply and Close" schließen
-
-5.  Im Package Explorer einen Rechtsklick auf den Eintrag für das
-    Spiel-Plugin unter "Referenced Libraries" machen (Spielname und
-    Jahreszahl, also z.B. "piranhas\_2019.jar") und Properties wählen
-
-6.  Links "Java Source Attachment" auswählen
-
-7.  Rechts "Workspace location" aktivieren und den Pfad zur Source-Jar
-    (im Ordner "lib" des Spielervorlagen-Quellcode-Pakets) einstellen
-    (heißt genau wie das Spiel-Plugin, mit einem "sources" angehängt,
-    also z.B. "piranhas\_2019-sources.jar")
-
-8.  Den Dialog mit "Apply and Close" schließen
+7. Dieser Schritt kann einen Moment dauern. Wenn alles erfolgreich war, steht unten in der Konsole "CONFIGURE         SUCCESFUL".
+   Falls es funktioniert hat geht man auf "Finish". Falls nicht überprüft man im Schritt davor die Gradle Version und die Version des JDK, dass angegeben ist
 
 ### Spielervorlage aus Eclipse starten
 
@@ -96,6 +87,42 @@ Damit die Spielervorlage erfolgreich startet, muss der
 :t[Spielleiter]{#server} laufen und auf eine Verbindung warten.
 :::
 
+## Einrichtung von IntelliJ
+
+Um IntelliJ zu installieren befilgt man folgende Schritte:
+
+ 1. Man geht auf die [IntelliJ-Website](https://www.jetbrains.com/idea/download/?section=windows) und läd sich IntelliJ Community herunter (Ist unten auf der Website zu finden)
+
+ 2. Wenn dies geschehen ist führt man die heruntergeladene .exe Datei aus und es öffnet sich ein Installer
+
+ 3. Nachdem man ausgewählt hat wo das Programm gespeichert werden soll, kommt man in ein Menü das Installation Options heißt. Hier wählt man
+    1. Add "Open Folder as Project"
+    2. .java
+    3. .gradle 
+   
+ 4. Im nächsten Menü wählt man Install aus
+
+ 5. Wenn der Instalationsprozess fertig ist geht man auf Finish
+
+
+### Spielervorlage in IntelliJ einbinden
+
+1. Spielervorlage herunterladen (von unserer Website unter allgemeine Dokumatation)
+
+2. Die heruntergeladene Zip extrahieren
+
+3. Man klickt auf Open (entweder im Startmenü neben New Project oder oben links über das Optionsmenü, wenn man bereits in einem Projekt ist)
+
+4. Nun wählt man die extrahierte Datei aus und klickt auf "Trust Project"
+
+5. Nach dem Import wählt man unten links das Hammersymbol aus und wenn alles funktioniert hat steht in der Konsole "BUILD SUCCESSFUL". Falls das nicht der Fall sein sollte tut man folgendes:
+   1. Man geht oben links auf Optionen (Das Symbol mit den 4 Strichen)
+   2. Man geht auf "File" und wählt dort "Project Structure" aus
+   3. Nun wählt man bei "SDK" (Software Devolopment Kit) die Version 15 aus und setzt das "Language Level" auf "SDK Default" ganz oben im Menü
+   4. Nun geht man auf Apply und schließt das Menü
+   5. Wenn man alle Schritte befolgt hat geht man nun wieder auf das Hammersymbol unten links und klickt auf das Refresh-Symbol bzw. auf "Sync Gradle Project" wenn man mit der Maus auf dem Botton ist.
+
 ## Weiterführende Links
 
 -   [Homepage der Eclipse-IDE](http://www.eclipse.org)
+-   [Homepage der IntelliJ-IDE](https://www.jetbrains.com/de-de/idea/)

--- a/hyperbook/book/entwicklung/einrichtung-der-entwicklungsumgebung.md
+++ b/hyperbook/book/entwicklung/einrichtung-der-entwicklungsumgebung.md
@@ -120,7 +120,7 @@ Um IntelliJ zu installieren befilgt man folgende Schritte:
    2. Man geht auf "File" und wählt dort "Project Structure" aus
    3. Nun wählt man bei "SDK" (Software Devolopment Kit) die Version 15 aus und setzt das "Language Level" auf "SDK Default" ganz oben im Menü
    4. Nun geht man auf Apply und schließt das Menü
-   5. Wenn man alle Schritte befolgt hat geht man nun wieder auf das Hammersymbol unten links und klickt auf das Refresh-Symbol bzw. auf "Sync Gradle Project" wenn man mit der Maus auf dem Botton ist.
+   5. Wenn man alle Schritte befolgt hat geht man nun wieder auf das Hammersymbol unten links und klickt auf das Refresh-Symbol bzw. auf "Sync Gradle Project" wenn man mit der Maus auf dem Button ist.
 
 ## Weiterführende Links
 

--- a/hyperbook/book/entwicklung/installation-von-java.md
+++ b/hyperbook/book/entwicklung/installation-von-java.md
@@ -16,10 +16,10 @@ Zum Entwickeln eigener Programme wird das JDK benötigt, dass auch das JRE enth�
 
 ## Installation
 
-Die Installation des JDK 17 auf einem Windows-System erfolgt mit folgendem `winget`-Befehl im Windows Terminal:
+Die Installation des JDK 15 auf einem Windows-System erfolgt mit folgendem `winget`-Befehl im Windows Terminal:
 
 ```bash
-winget install -e --id AdoptOpenJDK.OpenJDK.17
+winget install -e --id AdoptOpenJDK.OpenJDK.15
 ```
 
 ### Installation über Paketquellen (Linux)


### PR DESCRIPTION
JDK Version Change because it only runs with the JDK versions up to 15.
Export manual for Java in Eclipse and IntelliJ.
Linking export-manual in abgabe.md
Import fix for Eclipse and new import instructions for IntelliJ